### PR TITLE
fix: scheduler still broken — ResourceBase constructor coerces empty namespace

### DIFF
--- a/js/engine/ClusterState.js
+++ b/js/engine/ClusterState.js
@@ -588,8 +588,8 @@ export class ClusterState {
     const node = this.getByName('Node', nodeName, '');
     if (!node) return null;
 
-    const cpuSpec = node.spec.cpu || node.status.capacity?.cpu;
-    const memSpec = node.spec.memory || node.status.capacity?.memory;
+    const cpuSpec = node.spec.cpu || node.capacity?.cpu || node.status.capacity?.cpu;
+    const memSpec = node.spec.memory || node.capacity?.memory || node.status.capacity?.memory;
     const capacity = {
       cpu: cpuSpec ? this._parseCpu(cpuSpec) : 4000,
       memory: memSpec ? this._parseMemory(memSpec) : 8192,

--- a/js/resources/ClusterResources.js
+++ b/js/resources/ClusterResources.js
@@ -55,7 +55,8 @@ export class Node extends ResourceBase {
     this.heartbeatTimer = 0;
     this.heartbeatInterval = 10;
     this.isCordon = false;
-    this.setStatus('Ready');
+    this.status.conditions = this.conditions;
+    this.status.phase = 'Running';
   }
 
   _parseCpu(cpu) {

--- a/js/resources/ResourceBase.js
+++ b/js/resources/ResourceBase.js
@@ -15,7 +15,7 @@ export class ResourceBase {
       this.apiVersion = meta.apiVersion || 'v1';
       this.metadata = {
         name: meta.name || 'unnamed',
-        namespace: meta.namespace || 'default',
+        namespace: meta.namespace ?? 'default',
         uid: generateUID(),
         labels: meta.labels ? { ...meta.labels } : {},
         annotations: meta.annotations ? { ...meta.annotations } : {},


### PR DESCRIPTION
## Summary

PR #2 fixed `addResource()` to pass `namespace: ''` for cluster-scoped resources, but the fix never actually worked because `ResourceBase`'s constructor immediately converted it back to `'default'`.

Additionally, Nodes created via the palette (using the `Node` class) had two separate issues preventing scheduling.

## Root Causes

### 1. ResourceBase constructor coerces empty namespace (THE bug)

`ResourceBase.js` line 18:
```js
namespace: meta.namespace || 'default',  // '' || 'default' → 'default'
```

`addResource()` correctly computed `namespace: ''` for cluster-scoped resources, but the `ResourceBase` constructor's `||` operator converted empty string back to `'default'`. Every node was stored with namespace `'default'`, while `getNodeAllocatable()` looked them up with namespace `''` — always returning `null`.

**Fix**: `||` → `??` (nullish coalescing preserves empty string)

### 2. Node class conditions not synced to status.conditions

The `Node` class (ClusterResources.js) stored its Ready condition in `this.conditions` (its own property), but the scheduler called `isConditionTrue('Ready')` which reads `this.status.conditions` (from ResourceBase). These were different arrays — `this.status.conditions` was always empty for palette-created nodes.

**Fix**: `this.status.conditions = this.conditions` in the Node constructor

### 3. Node class capacity not found by getNodeAllocatable

The `Node` class stores capacity in `this.capacity.cpu` / `this.capacity.memory`, but `getNodeAllocatable()` only checked `node.spec.cpu` and `node.status.capacity.cpu`.

**Fix**: Also check `node.capacity?.cpu` / `node.capacity?.memory`

## Evidence from Issue #3

The user's exported YAML shows:
```yaml
kind: Node
metadata:
  name: node-1
  namespace: default    # ← should be "" for cluster-scoped
```
And all pods stuck:
```yaml
status:
  phase: Pending
  conditions:
    - type: PodScheduled
      status: False
      reason: Unschedulable
      message: No nodes available with sufficient resources
```

## Files Changed (3 files, +5/-4 lines)
- `js/resources/ResourceBase.js` — `||` → `??` for namespace
- `js/resources/ClusterResources.js` — sync conditions, set phase directly
- `js/engine/ClusterState.js` — check `node.capacity` in getNodeAllocatable

## Test plan
- [ ] Start Level 3, create 2 nodes via palette click, create 6 pods — pods should transition from Pending to Running within seconds
- [ ] Create nodes via `kubectl create node node-2` — node should appear as Ready
- [ ] Export YAML — nodes should show `namespace: ""` not `namespace: default`
- [ ] Verify Level 3 completes when 6 pods distributed across 2+ nodes

Fixes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node CPU and memory capacity resolution by checking multiple data sources for more accurate resource reporting
  * Enhanced node status initialization to properly reflect current readiness and phase conditions upon startup

* **Improvements**
  * Refined namespace fallback logic to correctly handle explicitly provided empty string values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->