### PR TITLE
fix: 9 gameplay bugs breaking campaign levels, scoring, and resource display

### DIFF
--- a/js/engine/GameEngine.js
+++ b/js/engine/GameEngine.js
@@ -401,7 +401,7 @@ export class GameEngine {
       this._commandHistory.shift();
     }
 
-    this.eventBus.emit('command:execute', command);
+    this.eventBus.emit('command:executed', command);
 
     switch (command.type) {
       case 'create':

--- a/js/engine/ScoringEngine.js
+++ b/js/engine/ScoringEngine.js
@@ -658,6 +658,7 @@ class ScoringEngine {
           });
         }
       } catch (e) {
+        console.warn('Achievement check error:', e);
       }
     }
 

--- a/js/modes/CampaignMode.js
+++ b/js/modes/CampaignMode.js
@@ -238,15 +238,20 @@ class CampaignMode {
           const nodes = state.getResourcesByKind('Node') || [];
           const daemonSets = state.getResourcesByKind('DaemonSet') || [];
           if (daemonSets.length > 0 && nodes.length > 0) {
-            obj.current = nodes.length;
+            const pods = state.getResourcesByKind('Pod') || [];
+            const dsPods = pods.filter((p) =>
+              p.metadata?.ownerReferences?.some((ref) => ref.kind === 'DaemonSet')
+            );
+            const coveredNodes = new Set(dsPods.map((p) => p.spec?.nodeName).filter(Boolean));
+            obj.current = coveredNodes.size;
             obj.target = nodes.length;
-            obj.completed = true;
+            obj.completed = coveredNodes.size >= nodes.length;
           }
           break;
         }
         case 'complete': {
           const jobs = state.getResourcesByKind(obj.kind) || [];
-          const completed = jobs.filter((j) => j.status?.phase === 'Completed');
+          const completed = jobs.filter((j) => j.status?.phase === 'Complete');
           obj.current = completed.length;
           obj.completed = obj.current >= obj.target;
           break;
@@ -266,7 +271,8 @@ class CampaignMode {
         case 'connect': {
           const services = state.getResourcesByKind('Service') || [];
           const hasConnection = services.some((s) =>
-            s.spec?.selector && (s.name === obj.to + '-svc' || s.name === obj.to)
+            s.spec?.selector && Object.keys(s.spec.selector).length > 0 &&
+            (s.name === obj.to + '-svc' || s.name === obj.to)
           );
           obj.current = hasConnection ? 1 : 0;
           obj.completed = hasConnection;

--- a/js/resources/WorkloadResources.js
+++ b/js/resources/WorkloadResources.js
@@ -42,6 +42,8 @@ export class Pod extends ResourceBase {
     this.startupTime = 1 + Math.random() * 3;
     this.ip = null;
     this.qosClass = this._calculateQoS();
+    this.status.conditions = this.conditions;
+    this.status.containerStatuses = this.containerStatuses;
     this.setStatus('Pending');
   }
 
@@ -130,6 +132,10 @@ export class Pod extends ResourceBase {
         });
       }
     }
+
+    this.status.phase = this.phase;
+    this.status.conditions = this.conditions;
+    this.status.containerStatuses = this.containerStatuses;
   }
 
   _triggerOOMKill() {
@@ -287,6 +293,7 @@ export class Deployment extends ResourceBase {
       { type: 'Available', status: 'True', reason: 'MinimumReplicasAvailable', lastTransitionTime: new Date().toISOString() },
       { type: 'Progressing', status: 'True', reason: 'NewReplicaSetAvailable', lastTransitionTime: new Date().toISOString() }
     ];
+    this.status.conditions = this.conditions;
     this.setStatus('Available');
   }
 
@@ -357,6 +364,8 @@ export class Deployment extends ResourceBase {
       this.readyReplicas += rs.readyReplicas || 0;
       this.availableReplicas += rs.availableReplicas || 0;
     }
+
+    this.status.conditions = this.conditions;
   }
 
   getShape() { return 'rounded-rect'; }

--- a/js/ui/InspectorPanel.js
+++ b/js/ui/InspectorPanel.js
@@ -106,10 +106,18 @@ export class InspectorPanel {
     const status = r.status?.phase || r.status?.state || 'Active';
 
     const iconMap = { Pod: 'P', Deployment: 'D', Service: 'S', Node: 'N', ConfigMap: 'C', Secret: 'K', Ingress: 'I', StatefulSet: 'SS', DaemonSet: 'DS' };
-    const colorMap = { Pod: 'sky', Deployment: 'blue', Service: 'purple', Node: 'green', ConfigMap: 'amber', Secret: 'red', Ingress: 'orange' };
-    const color = colorMap[kind] || 'sky';
+    const colorMap = {
+      Pod: ['bg-sky-500/20', 'text-sky-400'],
+      Deployment: ['bg-blue-500/20', 'text-blue-400'],
+      Service: ['bg-purple-500/20', 'text-purple-400'],
+      Node: ['bg-green-500/20', 'text-green-400'],
+      ConfigMap: ['bg-amber-500/20', 'text-amber-400'],
+      Secret: ['bg-red-500/20', 'text-red-400'],
+      Ingress: ['bg-orange-500/20', 'text-orange-400'],
+    };
+    const [bgColor, textColor] = colorMap[kind] || ['bg-sky-500/20', 'text-sky-400'];
 
-    document.getElementById('inspector-icon').className = `w-8 h-8 rounded-lg bg-${color}-500/20 flex items-center justify-center text-${color}-400 text-sm font-bold shrink-0`;
+    document.getElementById('inspector-icon').className = `w-8 h-8 rounded-lg ${bgColor} flex items-center justify-center ${textColor} text-sm font-bold shrink-0`;
     document.getElementById('inspector-icon').textContent = iconMap[kind] || kind[0];
     document.getElementById('inspector-name').textContent = name;
     document.getElementById('inspector-subtitle').textContent = `${kind} / ${ns} / ${status}`;


### PR DESCRIPTION
## Summary
- Fix Job phase mismatch (`'Completed'` → `'Complete'`) making Level 7+ uncompletable
- Fix DaemonSet coverage objective auto-passing without verifying pods on nodes
- Fix command event name mismatch (`command:execute` → `command:executed`) so stats track
- Fix Pod/Deployment property sync — `this.status.*` now mirrors top-level properties
- Fix Service connect objective accepting empty selectors
- Fix InspectorPanel dynamic Tailwind classes purged at build time (use static map)
- Fix ScoringEngine silently swallowing achievement check errors

## Test plan
- [ ] Start Level 7 — create Jobs, verify level completes when phase is 'Complete'
- [ ] Start Level 6 — create DaemonSet, verify it only completes when pods exist on all nodes
- [ ] Run multiple commands — verify Stats panel shows command count incrementing
- [ ] Create resources via palette — verify `kubectl describe` shows correct info
- [ ] Click inspector — verify colored status badges render correctly
- [ ] Check browser console — achievement errors should log warnings instead of being silent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed campaign mode objective tracking for coverage, job completion, and service connectivity
  * Improved status field synchronization for workload resources
  * Enhanced error logging for achievement validation

* **UI/Style**
  * Updated inspector panel icon colors for better visual consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->