### PR TITLE
fix(context menu): right-click on 3D resources

### DIFF
--- a/js/rendering/ClusterRenderer.js
+++ b/js/rendering/ClusterRenderer.js
@@ -201,7 +201,28 @@ export class ClusterRenderer {
         this._onMouseDown = this._handleMouseDown.bind(this);
         this._onMouseUp = this._handleMouseUp.bind(this);
         this._onResize = this._handleResize.bind(this);
-        this._onContextMenu = (e) => e.preventDefault();
+        this._onContextMenu = (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            const rect = this.canvas.getBoundingClientRect();
+            this.mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+            this.mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+            this.raycaster.setFromCamera(this.mouse, this.camera);
+            const intersects = this.raycaster.intersectObjects(this.pickableObjects, true);
+            if (intersects.length > 0) {
+                let target = intersects[0].object;
+                while (target.parent && !target.userData.resourceId) {
+                    target = target.parent;
+                }
+                if (target.userData.resourceId && window.game?.engine) {
+                    window.game.engine.emit('resource:contextmenu', {
+                        uid: target.userData.resourceId,
+                        x: e.clientX,
+                        y: e.clientY,
+                    });
+                }
+            }
+        };
 
         this.canvas.addEventListener('mousemove', this._onMouseMove);
         this.canvas.addEventListener('mousedown', this._onMouseDown);


### PR DESCRIPTION
The context menu was broken due to two issues in `ClusterRenderer`:

1. The `contextmenu` canvas listener only called `e.preventDefault()` and never performed a raycast or emitted `resource:contextmenu`, so ContextMenu.js never received the signal to show.

2. Even after emitting the event, the `contextmenu` event bubbled up to the document-level handler in ContextMenu.js which saw `visible === true` (just set by `show()`) and immediately called `hide()`, causing the menu to flash and disappear.

Fix:
update the canvas contextmenu handler to raycast the clicked position, emit `resource:contextmenu` with the resource uid and screen coordinates, and call `e.stopPropagation()` to prevent the document handler from closing the menu in the same event cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resource context menu interactions to properly respond to right-click events and capture relevant interaction details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->