### PR TITLE
fix: level completion modal never shows — event name mismatch

### DIFF
--- a/js/modes/CampaignMode.js
+++ b/js/modes/CampaignMode.js
@@ -449,7 +449,7 @@ class CampaignMode {
       this.usedHints
     );
 
-    this.gameEngine.emit('campaign:level-completed', {
+    const completionData = {
       levelId: this.currentLevel,
       title: this.currentLevelDef.title,
       stars: result.stars,
@@ -458,6 +458,12 @@ class CampaignMode {
       efficiency: Math.round(efficiency * 100),
       hadFailures: this.hadFailures,
       nextLevel: this.currentLevelDef.nextLevel
+    };
+
+    this.gameEngine.emit('campaign:level-completed', completionData);
+    this.gameEngine.emit('mode:level-complete', {
+      ...completionData,
+      message: `Completed in ${Math.round(completionTime)}s with ${Math.round(efficiency * 100)}% efficiency. +${result.xpEarned} XP`
     });
 
     return result;

--- a/js/modes/ChallengeMode.js
+++ b/js/modes/ChallengeMode.js
@@ -580,6 +580,11 @@ class ChallengeMode {
       stars: result.stars,
       xpEarned: result.xpEarned
     });
+    this.gameEngine.emit('mode:level-complete', {
+      title: `${this.currentChallengeDef.title} Complete!`,
+      stars: result.stars,
+      message: `Finished in ${Math.round(this.elapsedTime)}s / ${this.currentChallengeDef.timeLimit}s. +${result.xpEarned} XP`
+    });
 
     return result;
   }

--- a/js/modes/ChaosMode.js
+++ b/js/modes/ChaosMode.js
@@ -208,6 +208,9 @@ class ChaosMode {
     };
 
     this.gameEngine.emit('chaos:game-over', finalStats);
+    this.gameEngine.emit('mode:game-over', {
+      message: `Survived ${Math.round(this.survivalTime)}s | Wave ${this.waveNumber} | ${this.incidentsResolved} incidents resolved | Combo x${this.highestCombo}`
+    });
 
     return finalStats;
   }


### PR DESCRIPTION
## Summary
When all objectives are completed, nothing happens. No modal, no stars, no "Next Level" button. The level just sits there completed but the player has no way to proceed.

**Root cause**: Event name mismatch between modes and UI.

| Mode | Emits | UI Listens For |
|------|-------|---------------|
| CampaignMode | `campaign:level-completed` | `mode:level-complete` |
| ChallengeMode | `challenge:completed` | `mode:level-complete` |
| ChaosMode | `chaos:game-over` | `mode:game-over` |

The completion modal HTML exists (`#modal-level-complete`), the star display works, the "Next Level" and "Menu" buttons are wired — but the modal never activates because no mode emits the event name the UI expects.

**Fix**: Each mode now also emits the generic `mode:level-complete` or `mode:game-over` event alongside its specific event, with the data shape the UI expects (title, stars, message).

## Test plan
- [ ] Complete Level 1 — completion modal should appear with stars and "Next Level" button
- [ ] Click "Next Level" — should advance to Level 2
- [ ] Click "Menu" — should return to main menu
- [ ] Complete a Challenge — completion modal should show
- [ ] Die in Chaos mode — game over modal should show with survival stats

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Game mode completion events now emit structured performance data with timing metrics, efficiency percentages, and experience points.
  * Game over events now emit detailed statistical messages including survival time, wave information, and performance highlights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->