### PR TITLE
fix: incident resolve flows through to IncidentEngine, panel auto-shows

### DIFF
--- a/js/ui/IncidentPanel.js
+++ b/js/ui/IncidentPanel.js
@@ -118,11 +118,12 @@ export class IncidentPanel {
   _onNewIncident(data) {
     const incident = {
       id: this.nextId++,
-      type: data.type || 'Unknown',
+      engineIncidentId: data.id || null,
+      type: data.type || data.name || 'Unknown',
       severity: data.severity || 'warning',
-      resource: data.resource || 'unknown',
+      resource: data.resource || data.target || 'unknown',
       resourceUid: data.uid,
-      message: data.message || 'An incident occurred',
+      message: data.message || data.description || 'An incident occurred',
       timestamp: Date.now(),
       status: 'active',
       resolvedAt: null,
@@ -130,7 +131,8 @@ export class IncidentPanel {
     };
     this.incidents.unshift(incident);
     window.game?.engine.emit('incident:count', { count: this._getActiveCount() });
-    if (this.visible) this._renderList();
+    this.show();
+    this._renderList();
   }
 
   addIncident(type, severity, resource, message, uid) {
@@ -142,6 +144,12 @@ export class IncidentPanel {
     if (!incident || incident.status === 'resolved') return;
     incident.status = 'resolved';
     incident.resolvedAt = Date.now();
+
+    const incidentEngine = window.game?.incidentEngine;
+    if (incidentEngine && incident.engineIncidentId) {
+      incidentEngine.resolveIncident(incident.engineIncidentId, 'manual');
+    }
+
     window.game?.engine.emit('incident:resolved', { id, type: incident.type });
     window.game?.engine.emit('incident:count', { count: this._getActiveCount() });
     window.game?.engine.emit('xp:gain', { amount: this._getXPForResolve(incident) });


### PR DESCRIPTION
## Summary
Level 4 (and all incident-based levels) can't be completed because:

1. **Incident panel stays hidden** — incidents fire but the panel doesn't open, so users don't know they exist
2. **Resolve button doesn't count** — IncidentPanel.resolveIncident() only updates UI state, never calls incidentEngine.resolveIncident(). CampaignMode checks incidentEngine.getStats().totalResolved which stays at 0.
3. **Field mapping mismatch** — IncidentEngine sends {name, target, description} but panel reads {type, resource, message}, showing "Unknown" everywhere

**Fix**: Panel auto-shows on new incidents, stores engineIncidentId, calls through to IncidentEngine on resolve, and reads both field name shapes.

## Test plan
- [ ] Start Level 4 — incident panel should auto-open at ~10s showing "CrashLoopBackOff"
- [ ] Click "Resolve" — objective counter should increment
- [ ] All objectives complete — completion modal should appear (from PR #12)