### PR TITLE
feat: add K8s Draw button to main menu + update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 Learn Kubernetes by playing. Deploy pods, fix CrashLoopBackOff, type real kubectl commands — all in a 3D sim that runs in your browser.
 
-**[Play Now at k8sgames.com](https://k8sgames.com)**
+**[Play Now at k8sgames.com](https://k8sgames.com)** | **[K8s Draw — 3D Architecture Diagrams](https://k8sgames.com/draw)**
 
 ![K8s Games — 3D Kubernetes cluster simulation in the browser](screenshot.png)
 
 ## Get Started
 
 Visit **[k8sgames.com](https://k8sgames.com)** and pick a mode. No install, no signup, no build step.
+
+Just here to diagram? Go straight to **[k8sgames.com/draw](https://k8sgames.com/draw)** — drag K8s resources onto a 3D canvas, draw connections, export YAML or PNG, and share via URL.
 
 Or run locally:
 
@@ -38,6 +40,21 @@ python3 -m http.server 8080
 | **Chaos** | Endless survival. Incidents escalate until your cluster breaks. How long can you last? |
 | **Sandbox** | Free build. Design any cluster, get scored 0-100 by the Architecture Advisor |
 | **Challenges** | 10 timed scenarios. Deploy apps, fix outages, race the clock |
+
+### K8s Draw (`/draw`)
+
+A 3D Kubernetes architecture whiteboard. Like Excalidraw but for K8s.
+
+- Drag-drop 21 resource types onto a 3D canvas
+- Draw connection lines between resources
+- Double-click to rename any resource
+- Auto-layout organizes by tier (Nodes, Workloads, Networking, Storage, RBAC)
+- Export as YAML (with correct apiVersions) or PNG
+- Share diagrams via URL — one-click copy, open anywhere
+- Edit properties: name, namespace, labels, replicas
+- Right-click to delete, `Del` key for selected
+
+No game logic, no incidents, no scoring — just diagramming.
 
 ## Controls
 

--- a/index.html
+++ b/index.html
@@ -96,6 +96,12 @@
       </button>
     </div>
 
+    <a href="/draw" class="menu-draw-link">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
+      <span>K8s Draw</span>
+      <span class="menu-draw-desc">Design K8s architectures in 3D. Drag resources, draw connections, export YAML.</span>
+    </a>
+
     <div class="menu-footer">
       <button class="menu-footer-btn" id="btn-settings">Settings</button>
       <button class="menu-footer-btn" id="btn-achievements">Achievements</button>

--- a/style.css
+++ b/style.css
@@ -249,8 +249,42 @@ html, body {
   height: 24px;
 }
 
+.menu-draw-link {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 2rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: 10px;
+  border: 1px solid rgba(50, 108, 229, 0.3);
+  background: rgba(50, 108, 229, 0.08);
+  color: var(--k8s-blue-light);
+  text-decoration: none;
+  transition: all 0.2s;
+  max-width: 480px;
+  width: 100%;
+}
+
+.menu-draw-link:hover {
+  border-color: var(--k8s-blue);
+  background: rgba(50, 108, 229, 0.15);
+  color: #fff;
+}
+
+.menu-draw-link span:first-of-type {
+  font-weight: 600;
+  font-size: 0.875rem;
+  white-space: nowrap;
+}
+
+.menu-draw-desc {
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  font-weight: 400 !important;
+}
+
 .menu-footer {
-  margin-top: 3rem;
+  margin-top: 2rem;
   display: flex;
   gap: 1.5rem;
   align-items: center;


### PR DESCRIPTION
## Summary

- Add **K8s Draw** link to the main menu homepage, between game mode buttons and footer
- Update README with Draw documentation

### Main Menu Change
New styled link below the 4 game mode buttons:
- Pencil icon + "K8s Draw" title + description
- K8s blue accent border, hover effect
- Links to `/draw` — opens the 3D architecture diagramming tool

### README Changes
- Added Draw link in header next to "Play Now"
- Added "just here to diagram?" shortcut in Get Started section
- Added full K8s Draw feature list under Game Modes section

## Test plan
- [ ] Open k8sgames.com — "K8s Draw" link visible below game modes
- [ ] Click it — navigates to /draw
- [ ] Hover effect works (blue border brightens)
- [ ] Mobile: link wraps properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * K8s Draw: A new 3D Kubernetes whiteboard experience is now accessible from the main menu. Design Kubernetes architectures with drag-and-drop resource types, connection lines, auto-layout by tier, rename capabilities, editable properties such as labels and replicas, YAML and PNG export, URL-based sharing, and deletion via context menu or Delete key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->