### PR TITLE
fix: draw mode rename not updating 3D labels

### DIFF
--- a/draw.html
+++ b/draw.html
@@ -551,24 +551,15 @@
             if (newName && newName !== resource.metadata.name) {
               resource.metadata.name = newName;
               resource.name = newName;
-              const group = this.renderer.resourceMeshes.get(uid);
-              if (group) {
-                const oldLabel = group.children.find(c => c.userData?.isLabel);
-                if (oldLabel) {
-                  oldLabel.material.map.dispose();
-                  oldLabel.material.dispose();
-                  group.remove(oldLabel);
-                }
-                const pos = this.placedPositions.get(uid) || { x: 0, z: 0 };
-                this.renderer.removeResource(uid);
-                const renderable = {
-                  id: uid, type: resource.kind, name: newName,
-                  namespace: resource.metadata.namespace || 'default',
-                  status: resource.status?.phase || 'Running',
-                  x: pos.x, y: 0, z: pos.z,
-                };
-                this.renderer.addResource(renderable);
-              }
+              const pos = this.placedPositions.get(uid) || { x: 0, z: 0 };
+              this.renderer.removeResource(uid);
+              this.renderer.addResource({
+                id: uid, type: resource.kind, name: newName,
+                namespace: resource.metadata.namespace || 'default',
+                status: 'Running',
+                x: pos.x, y: 0, z: pos.z,
+              });
+              this.syncConnections();
             }
             input.remove();
           };
@@ -756,16 +747,7 @@
             if (k) newLabels[k.trim()] = (v.join('=') || '').trim();
           }
 
-          const updates = {
-            metadata: { labels: newLabels },
-          };
-
-          if (newName && newName !== resource.metadata.name) {
-            resource.metadata.name = newName;
-          }
-          if (newNs && newNs !== resource.metadata.namespace) {
-            resource.metadata.namespace = newNs;
-          }
+          const updates = { metadata: { labels: newLabels } };
 
           const replicasInput = document.getElementById('prop-replicas');
           if (replicasInput) {
@@ -774,6 +756,31 @@
           }
 
           this.engine.cluster.update(uid, updates);
+
+          const nameChanged = newName && newName !== resource.metadata.name;
+          const nsChanged = newNs && newNs !== resource.metadata.namespace;
+
+          if (nameChanged) {
+            resource.metadata.name = newName;
+            resource.name = newName;
+          }
+          if (nsChanged) {
+            resource.metadata.namespace = newNs;
+          }
+
+          if (nameChanged || nsChanged) {
+            const pos = this.placedPositions.get(uid) || { x: 0, z: 0 };
+            this.renderer.removeResource(uid);
+            this.renderer.addResource({
+              id: uid,
+              type: resource.kind,
+              name: resource.metadata.name,
+              namespace: resource.metadata.namespace,
+              status: 'Running',
+              x: pos.x, y: 0, z: pos.z,
+            });
+            this.syncConnections();
+          }
         });
 
         document.getElementById('prop-delete').addEventListener('click', () => {


### PR DESCRIPTION
## Problem

In K8s Draw, renaming resources via Apply Changes or double-click didn't update the 3D mesh label. The data changed but the visual stayed the same.

## Root Cause

`resource.metadata.name` was updated directly, but the 3D mesh (with its canvas-rendered label sprite) was never re-rendered. The `cluster.update()` method doesn't support name changes (K8s doesn't either), so the mesh factory never recreated the label.

## Fix

After name or namespace change, remove the old mesh and add a new one:
```
this.renderer.removeResource(uid);
this.renderer.addResource({ id: uid, name: newName, ... });
this.syncConnections();
```

Applied to both:
- **Apply Changes button** in properties panel
- **Double-click rename** inline input

## Test plan
- [ ] Place a Pod, double-click it, type new name, press Enter → label updates
- [ ] Place a Deployment, click it, change name in properties panel, click Apply → label updates
- [ ] Change namespace in properties panel → reflected in YAML export
- [ ] Connection lines preserved after rename

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource name update workflow to properly refresh labels and connection lines.
  * Enhanced property updates to correctly apply name and namespace changes to resource metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->