### PR TITLE
Fix K8s Draw broken rendering — shader compilation failure

### DIFF
--- a/js/rendering/ParticleTraffic.js
+++ b/js/rendering/ParticleTraffic.js
@@ -117,8 +117,7 @@ export class ParticleTrafficSystem {
             fragmentShader,
             transparent: true,
             depthWrite: false,
-            blending: THREE.AdditiveBlending,
-            vertexColors: true
+            blending: THREE.AdditiveBlending
         });
     }
 


### PR DESCRIPTION
## Summary
- K8s Draw (`/draw`) renders all resources as corrupted colored rectangles instead of 3D shapes
- **Root cause**: PR #26 added `attribute vec3 color` to the ParticleTraffic vertex shader while keeping `vertexColors: true` on the `ShaderMaterial`. In Three.js r152, `vertexColors: true` auto-injects `attribute vec3 color` into the shader prefix, causing a **duplicate attribute declaration** → GLSL compile error → `useProgram: program not valid`
- The invalid shader program corrupts the WebGL render state, causing ALL subsequent draw calls in the frame to fail
- **Fix**: Remove `vertexColors: true` since the custom shader handles the `color` attribute directly

Console error was: `WebGL: INVALID_OPERATION: useProgram: program not valid` (hundreds per second)

## Test plan
- [ ] Open https://k8sgames.com/draw — resources render as proper 3D shapes
- [ ] Place Pod, Deployment, Service — all display correctly
- [ ] Start Campaign mode — particle traffic still shows colored particles (not white)
- [ ] No WebGL errors in console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted particle rendering configuration for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->