### PR TITLE
fix: restructure K8s Draw auto-layout to match Kubernetes architecture

### DIFF
--- a/draw.html
+++ b/draw.html
@@ -992,16 +992,19 @@
         if (allResources.length === 0) return;
 
         const tiers = {
-          namespace:  { kinds: ['Namespace'], z: -10, spacing: 5 },
-          node:       { kinds: ['Node'], z: -5, spacing: 6 },
-          workload:   { kinds: ['Deployment', 'StatefulSet', 'DaemonSet', 'ReplicaSet'], z: 0, spacing: 4 },
+          ingress:    { kinds: ['Ingress', 'NetworkPolicy'], z: -12, spacing: 4 },
+          service:    { kinds: ['Service'], z: -8, spacing: 4 },
+          scaling:    { kinds: ['HorizontalPodAutoscaler', 'PodDisruptionBudget'], z: -4, spacing: 3.5 },
+          workload:   { kinds: ['Deployment', 'StatefulSet', 'DaemonSet'], z: 0, spacing: 4 },
           batch:      { kinds: ['Job', 'CronJob'], z: 3, spacing: 3.5 },
-          pod:        { kinds: ['Pod'], z: 6, spacing: 2.5 },
-          network:    { kinds: ['Service', 'Ingress', 'NetworkPolicy'], z: 10, spacing: 4 },
+          replicaset: { kinds: ['ReplicaSet'], z: 6, spacing: 3 },
+          pod:        { kinds: ['Pod'], z: 10, spacing: 2.5 },
           config:     { kinds: ['ConfigMap', 'Secret'], z: 14, spacing: 3.5 },
-          storage:    { kinds: ['PersistentVolumeClaim', 'PersistentVolume', 'StorageClass'], z: 17, spacing: 4 },
-          scaling:    { kinds: ['HorizontalPodAutoscaler', 'ResourceQuota', 'LimitRange', 'PodDisruptionBudget'], z: 20, spacing: 3.5 },
-          rbac:       { kinds: ['ServiceAccount', 'Role', 'ClusterRole', 'RoleBinding', 'ClusterRoleBinding'], z: 23, spacing: 3 },
+          storage:    { kinds: ['PersistentVolumeClaim', 'PersistentVolume', 'StorageClass'], z: 18, spacing: 4 },
+          quota:      { kinds: ['ResourceQuota', 'LimitRange'], z: 21, spacing: 3 },
+          rbac:       { kinds: ['ServiceAccount', 'Role', 'ClusterRole', 'RoleBinding', 'ClusterRoleBinding'], z: 24, spacing: 3 },
+          namespace:  { kinds: ['Namespace'], z: 27, spacing: 5 },
+          node:       { kinds: ['Node'], z: 31, spacing: 6 },
         };
 
         const targets = new Map();


### PR DESCRIPTION
## Summary
- Reorders auto-layout tiers to follow proper Kubernetes architecture hierarchy per kubernetes.io/docs/concepts/overview/components/
- Splits ReplicaSet into its own tier between Deployments and Pods to reflect the Deployment→ReplicaSet→Pod ownership chain
- Moves Ingress/NetworkPolicy to top (external access) and Node/Namespace to bottom (infrastructure/boundaries)
- Separates HPA/PDB (workload scaling) from ResourceQuota/LimitRange (namespace governance)

**New tier order (top → bottom):**
1. Ingress / NetworkPolicy — external access
2. Service — internal routing
3. HPA / PDB — scaling controllers
4. Deployment / StatefulSet / DaemonSet — workload controllers
5. Job / CronJob — batch
6. ReplicaSet — pod management
7. Pod — running containers
8. ConfigMap / Secret — configuration
9. PVC / PV / StorageClass — storage
10. ResourceQuota / LimitRange — governance
11. RBAC (ServiceAccount, Roles, Bindings) — access control
12. Namespace — logical boundaries
13. Node — infrastructure

## Test plan
- [ ] Open K8s Draw, add resources of various kinds
- [ ] Click auto-layout — verify Ingress at top, Nodes at bottom
- [ ] Verify Deployment → ReplicaSet → Pod vertical ordering
- [ ] Verify Services sit between Ingress and workloads