### PR TITLE
fix: Inspector panel editing, PVC auto-binding, headless service support, and resource heal/reschedule events

### DIFF
--- a/index.html
+++ b/index.html
@@ -1205,10 +1205,30 @@
 
         let extraFields = '';
         if (kind === 'Deployment' || kind === 'StatefulSet' || kind === 'ReplicaSet') {
+          const memReq = resource.spec?.resources?.requests?.memory || '128Mi';
+          const memLim = resource.spec?.resources?.limits?.memory || '256Mi';
+          const cpuReq = resource.spec?.resources?.requests?.cpu || '';
+          const cpuLim = resource.spec?.resources?.limits?.cpu || '';
+          const hasProbes = !!resource.spec?.livenessProbe;
+          
           extraFields += `
             <div class="mt-3">
               <div class="text-[10px] text-white/40 uppercase tracking-wider mb-1">Replicas</div>
               <input id="edit-replicas" type="number" min="0" max="20" value="${resource.spec?.replicas ?? 1}" class="w-full px-3 py-1.5 text-sm text-white bg-black/40 border border-white/15 rounded-lg outline-none focus:border-sky-500/50 font-mono" />
+            </div>
+            <div class="mt-3">
+              <div class="text-[10px] text-white/40 uppercase tracking-wider mb-1">Memory Request & Limit</div>
+              <div class="flex gap-2">
+                <input id="edit-mem-req" type="text" value="${cpuReq ? memReq : ''}" placeholder="Req e.g. 128Mi" class="w-1/2 px-3 py-1.5 text-sm text-white bg-black/40 border border-white/15 rounded-lg outline-none focus:border-sky-500/50 font-mono" />
+                <input id="edit-mem-lim" type="text" value="${cpuLim ? memLim : ''}" placeholder="Lim e.g. 256Mi" class="w-1/2 px-3 py-1.5 text-sm text-white bg-black/40 border border-white/15 rounded-lg outline-none focus:border-sky-500/50 font-mono" />
+              </div>
+            </div>
+            <div class="mt-3">
+              <div class="text-[10px] text-white/40 uppercase tracking-wider mb-1">Production Readiness</div>
+              <label class="flex items-center gap-2 mt-1">
+                <input type="checkbox" id="edit-probes" ${hasProbes ? 'checked' : ''} class="rounded border-white/15 bg-black/40 text-sky-500">
+                <span class="text-xs text-white/80">Enable Liveness & Readiness Probes</span>
+              </label>
             </div>`;
         }
         if (kind === 'Secret') {
@@ -1251,6 +1271,11 @@
                 <option value="NodePort" ${resource.spec?.type === 'NodePort' ? 'selected' : ''}>NodePort</option>
                 <option value="LoadBalancer" ${resource.spec?.type === 'LoadBalancer' ? 'selected' : ''}>LoadBalancer</option>
               </select>
+            </div>
+            <div class="mt-3">
+              <div class="text-[10px] text-white/40 uppercase tracking-wider mb-1">Cluster IP</div>
+              <input id="edit-cluster-ip" type="text" value="${resource.spec?.clusterIP || ''}" placeholder='e.g. "None"' class="w-full px-3 py-1.5 text-sm text-white bg-black/40 border border-white/15 rounded-lg outline-none focus:border-sky-500/50 font-mono" />
+              <div class="text-[10px] text-white/30 mt-1">Leave empty for auto-assign, or "None" for Headless</div>
             </div>`;
         }
 
@@ -1305,6 +1330,24 @@
           if (replicasInput) {
             updates.spec = updates.spec || {};
             updates.spec.replicas = parseInt(replicasInput.value, 10) || 1;
+            
+            const memReq = document.getElementById('edit-mem-req');
+            const memLim = document.getElementById('edit-mem-lim');
+            if (memReq && memLim && memReq.value.trim() && memLim.value.trim()) {
+              updates.spec.resources = {
+                requests: { cpu: '100m', memory: memReq.value.trim() },
+                limits: { cpu: '500m', memory: memLim.value.trim() }
+              };
+            }
+
+            const probesCheck = document.getElementById('edit-probes');
+            if (probesCheck && probesCheck.checked) {
+              updates.spec.livenessProbe = { httpGet: { path: '/health', port: 80 } };
+              updates.spec.readinessProbe = { httpGet: { path: '/ready', port: 80 } };
+            } else if (probesCheck) {
+              updates.spec.livenessProbe = null;
+              updates.spec.readinessProbe = null;
+            }
           }
 
           const selectorInput = document.getElementById('edit-selector');
@@ -1323,6 +1366,16 @@
           if (svcType) {
             updates.spec = updates.spec || {};
             updates.spec.type = svcType.value;
+          }
+
+          const clusterIpInput = document.getElementById('edit-cluster-ip');
+          if (clusterIpInput) {
+            let val = clusterIpInput.value.trim();
+            if (val) {
+              if (val.toLowerCase() === 'none') val = 'None';
+              updates.spec = updates.spec || {};
+              updates.spec.clusterIP = val;
+            }
           }
 
           const secretType = document.getElementById('edit-secret-type');

--- a/index.html
+++ b/index.html
@@ -1211,6 +1211,26 @@
               <input id="edit-replicas" type="number" min="0" max="20" value="${resource.spec?.replicas ?? 1}" class="w-full px-3 py-1.5 text-sm text-white bg-black/40 border border-white/15 rounded-lg outline-none focus:border-sky-500/50 font-mono" />
             </div>`;
         }
+        if (kind === 'Secret') {
+          extraFields += `
+            <div class="mt-3">
+              <div class="text-[10px] text-white/40 uppercase tracking-wider mb-1">Secret Type</div>
+              <select id="edit-secret-type" class="w-full px-3 py-1.5 text-sm text-white bg-black/40 border border-white/15 rounded-lg outline-none focus:border-sky-500/50">
+                <option value="Opaque" ${resource.type === 'Opaque' ? 'selected' : ''}>Opaque</option>
+                <option value="kubernetes.io/tls" ${resource.type === 'kubernetes.io/tls' ? 'selected' : ''}>kubernetes.io/tls</option>
+                <option value="kubernetes.io/dockerconfigjson" ${resource.type === 'kubernetes.io/dockerconfigjson' ? 'selected' : ''}>kubernetes.io/dockerconfigjson</option>
+              </select>
+            </div>`;
+        }
+        if (kind === 'Ingress') {
+          const defaultTlsSecret = resource.spec?.tls?.[0]?.secretName || '';
+          extraFields += `
+            <div class="mt-3">
+              <div class="text-[10px] text-white/40 uppercase tracking-wider mb-1">TLS Secret Name</div>
+              <input id="edit-ingress-tls" type="text" value="${defaultTlsSecret}" placeholder="e.g. my-tls" class="w-full px-3 py-1.5 text-sm text-white bg-black/40 border border-white/15 rounded-lg outline-none focus:border-sky-500/50 font-mono" />
+              <div class="text-[10px] text-white/30 mt-1">Leave blank to disable TLS</div>
+            </div>`;
+        }
         if (kind === 'Service') {
           const selectorStr = Object.entries(resource.spec?.selector || {}).map(([k,v]) => `${k}=${v}`).join(', ');
           const deployments = this.engine.cluster.getByKind('Deployment');
@@ -1303,6 +1323,22 @@
           if (svcType) {
             updates.spec = updates.spec || {};
             updates.spec.type = svcType.value;
+          }
+
+          const secretType = document.getElementById('edit-secret-type');
+          if (secretType && kind === 'Secret') {
+            resource.type = secretType.value;
+          }
+
+          const ingressTls = document.getElementById('edit-ingress-tls');
+          if (ingressTls && kind === 'Ingress') {
+            updates.spec = updates.spec || {};
+            const sn = ingressTls.value.trim();
+            if (sn) {
+              updates.spec.tls = [{ hosts: [resource.metadata.name + '.example.com'], secretName: sn }];
+            } else {
+              updates.spec.tls = [];
+            }
           }
 
           this.engine.cluster.update(uid, updates);

--- a/js/engine/GameEngine.js
+++ b/js/engine/GameEngine.js
@@ -213,6 +213,45 @@ export class GameEngine {
       this._reputation = Math.max(0, this._reputation - 5);
     });
 
+    this.eventBus.on('resource:healed', (data) => {
+      if (!data.target || !data.kind || !this.cluster) return;
+      const resources = this.cluster.getResourcesByKind(data.kind);
+      const res = resources.find(r => r.metadata?.name === data.target);
+      if (res) {
+        if (data.kind === 'Node') {
+          res.status.phase = 'Running';
+          res.setCondition('Ready', 'True', 'KubeletReady');
+        } else if (data.kind === 'Pod') {
+          res.status.phase = 'Running';
+          res.setCondition('Ready', 'True', 'ContainersReady');
+          if (res.status.containerStatuses) {
+            for (const cs of res.status.containerStatuses) {
+              cs.ready = true;
+              cs.state = { running: { startedAt: new Date().toISOString() } };
+            }
+          }
+        }
+      }
+    });
+
+    this.eventBus.on('resource:rescheduled', (data) => {
+      if (!data.target || !this.cluster) return;
+      const pods = this.cluster.getResourcesByKind('Pod') || [];
+      const isNode = (this.cluster.getResourcesByKind('Node') || []).some(n => n.metadata?.name === data.target);
+      
+      if (isNode) {
+        const podsOnNode = pods.filter(p => p.spec?.nodeName === data.target);
+        for (const p of podsOnNode) {
+          this.cluster.remove(p.uid);
+        }
+      } else {
+        const podToDelete = pods.find(p => p.metadata?.name === data.target);
+        if (podToDelete) {
+          this.cluster.remove(podToDelete.uid);
+        }
+      }
+    });
+
     this.eventBus.on('hpa:scaled', (data) => {
       this._addNotification('info', `HPA scaled ${data.target} ${data.direction} to ${data.to} replicas`);
       if (data.direction === 'up') {

--- a/js/engine/SimulationTick.js
+++ b/js/engine/SimulationTick.js
@@ -56,6 +56,7 @@ export class SimulationTick {
     this._tickStatefulSets(dt);
     this._tickDaemonSets(dt);
     this._tickJobs(dt);
+    this._tickPVCBinding(dt);
 
     if (this.tickCount % this.cronCheckInterval === 0) {
       this._tickCronJobs(dt);
@@ -975,6 +976,68 @@ export class SimulationTick {
 
   _randomSuffix() {
     return Math.random().toString(36).substring(2, 7);
+  }
+
+  _tickPVCBinding(dt) {
+    const pvcs = this.cluster.getByKind('PersistentVolumeClaim')
+      .filter((pvc) => pvc.phase === 'Pending' || pvc.status?.phase === 'Pending');
+    if (pvcs.length === 0) return;
+
+    const pvs = this.cluster.getByKind('PersistentVolume')
+      .filter((pv) => {
+        const phase = pv.phase || pv.status?.phase;
+        return phase === 'Available' || (phase === 'Pending' && !pv.spec?.claimRef);
+      });
+
+    for (const pvc of pvcs) {
+      let bestPV = null;
+      let bestPVCap = Infinity;
+
+      const pvcClass = pvc.spec?.storageClassName || 'standard';
+      const pvcStorage = pvc.spec?.resources?.requests?.storage || '10Gi';
+      const pvcCap = pvc.capacityBytes !== undefined ? pvc.capacityBytes : this.cluster._parseMemory(pvcStorage);
+
+      for (const pv of pvs) {
+        const pvPhase = pv.phase || pv.status?.phase;
+        if (pvPhase !== 'Available' && pvPhase !== 'Pending') continue;
+        if (pv.spec?.claimRef) continue;
+        
+        const pvClass = pv.spec?.storageClassName || 'standard';
+        if (pvClass !== pvcClass) continue;
+        
+        const pvStorage = pv.spec?.capacity?.storage || '10Gi';
+        const pvCap = pv.capacityBytes !== undefined ? pv.capacityBytes : this.cluster._parseMemory(pvStorage);
+
+        if (pvCap >= pvcCap) {
+          if (!bestPV || pvCap < bestPVCap) {
+            bestPV = pv;
+            bestPVCap = pvCap;
+          }
+        }
+      }
+
+      if (bestPV) {
+        if (typeof pvc.bind === 'function') {
+          pvc.bind(bestPV.metadata.name);
+        } else {
+          pvc.setPhase('Bound');
+          pvc.spec = pvc.spec || {};
+          pvc.spec.volumeName = bestPV.metadata.name;
+          pvc.recordEvent('Normal', 'Bound', `Bound to pv ${bestPV.metadata.name}`);
+        }
+
+        if (typeof bestPV.bind === 'function') {
+          bestPV.bind(pvc.metadata.name, pvc.metadata.namespace, pvc.metadata.uid);
+        } else {
+          bestPV.setPhase('Bound');
+          bestPV.spec = bestPV.spec || {};
+          bestPV.spec.claimRef = { name: pvc.metadata.name, namespace: pvc.metadata.namespace, uid: pvc.metadata.uid };
+          bestPV.recordEvent('Normal', 'Bound', `Bound to pvc ${pvc.metadata.name}`);
+        }
+
+        bestPV.phase = 'Bound';
+      }
+    }
   }
 }
 

--- a/js/resources/StorageResources.js
+++ b/js/resources/StorageResources.js
@@ -180,8 +180,6 @@ export class PersistentVolumeClaim extends ResourceBase {
     this.phase = 'Pending';
     this.boundVolume = null;
     this.capacity = null;
-    this.bindingTimer = 0;
-    this.bindingDelay = 1 + Math.random() * 3;
     this.mountedBy = [];
     this.usedBytes = 0;
     this.capacityBytes = parseStorage(this.spec.resources.requests.storage);
@@ -240,14 +238,6 @@ export class PersistentVolumeClaim extends ResourceBase {
 
   tick(deltaTime) {
     super.tick(deltaTime);
-
-    if (this.phase === 'Pending') {
-      this.bindingTimer += deltaTime;
-      if (this.bindingTimer >= this.bindingDelay) {
-        const pvName = `pv-${this.uid.substring(0, 8)}`;
-        this.bind(pvName);
-      }
-    }
 
     if (this.phase === 'Bound' && this.mountedBy.length > 0) {
       this.usedBytes = Math.min(

--- a/js/ui/CommandBar.js
+++ b/js/ui/CommandBar.js
@@ -643,6 +643,21 @@ export class CommandBar {
     };
 
     const def = defaults[kind] || { spec: {}, status: {} };
+
+    const ipArgIdx = args.indexOf('--clusterip');
+    if (ipArgIdx !== -1 && args[ipArgIdx + 1] && kind === 'Service') {
+      let ipVal = args[ipArgIdx + 1];
+      if (ipVal.toLowerCase() === 'none') ipVal = 'None';
+      def.spec.clusterIP = ipVal;
+    } else {
+      const inlineIp = args.find(a => a.startsWith('--clusterip='));
+      if (inlineIp && kind === 'Service') {
+        let ipVal = inlineIp.split('=')[1];
+        if (ipVal.toLowerCase() === 'none') ipVal = 'None';
+        def.spec.clusterIP = ipVal;
+      }
+    }
+
     const added = cluster.addResource({
       kind,
       name,


### PR DESCRIPTION
## Summary

This PR addresses several gaps in the inspector panel, simulation engine, and command bar that were preventing correct resource configuration and level validation.

---

## Changes

### Inspector Panel - index.html

- **Memory Request & Limit fields** added for Deployment, StatefulSet, and ReplicaSet resources. Users can now set memory requests and limits directly from the inspector without going through YAML. Values are saved into spec.resources.requests and spec.resources.limits.
- - **Liveness & Readiness Probe toggle** added. A checkbox labeled "Enable Liveness & Readiness Probes" allows enabling or disabling health probes on workloads. When enabled, sets livenessProbe and readinessProbe with an HTTP GET on /health and /ready respectively.
- - **Cluster IP field** added for Service resources. Users can now enter a specific cluster IP or type None to create a headless service. A helper note explains auto-assign vs headless behavior.
- - All new fields persist correctly when the Apply button is clicked.
---

### Simulation Engine - js/engine/SimulationTick.js

- Added _tickPVCBinding(dt) method that runs every simulation tick and automatically binds pending PersistentVolumeClaims to available PersistentVolumes.
- - Matching logic respects storageClassName and capacity - picks the smallest PV that satisfies the PVC storage request (best-fit).
- - Handles both the bind() method (if present on the resource) and a manual fallback that sets phase, spec.volumeName, and spec.claimRef directly.
- - Replaces the old per-PVC timer-based self-binding that was creating phantom PV names.
---

### Storage Resources - js/resources/StorageResources.js

- Removed the bindingTimer and bindingDelay fields from PersistentVolumeClaim.
- - Removed the timer-based tick() logic that previously auto-bound a PVC to a fake pv-<uid> name after a random delay. This was causing PVCs to bind to non-existent PVs.
- - PVC binding is now handled centrally by SimulationTick._tickPVCBinding(), which matches against real PVs in the cluster.
---

### Game Engine - js/engine/GameEngine.js

- Added handler for the resource:healed event. When fired with a kind and target name, the engine finds the matching resource and restores its status.
- - For Node: sets phase to Running and marks the Ready condition as True.
- - For Pod: sets phase to Running, marks containers as ready, and updates container state to running.
- - Added handler for the resource:rescheduled event. When fired targeting a Node, all pods with spec.nodeName matching that node are removed from the cluster. When targeting a Pod directly, just that pod is removed - simulating eviction and rescheduling.
---

### Command Bar - js/ui/CommandBar.js

- Added --clusterip flag support when creating a Service via the command bar.
- - Supports both --clusterip None (space-separated) and --clusterip=None (inline equals) syntax.
- - Normalises casing - none, NONE, etc. are all converted to None for Kubernetes headless service compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resource editor now displays configuration options specific to resource type: memory limits and probes for workloads, type selection for secrets, TLS settings for ingresses, and Cluster IP field for services.
  * Persistent Volume Claims now automatically bind to matching Persistent Volumes during simulation.
  * Added resource healing and rescheduling event simulation capabilities.
  * Services now support Cluster IP configuration via command line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->