### PR TITLE
chore: edge cache headers + UA-deflect bots + agent-aware robots

### DIFF
--- a/draw.html
+++ b/draw.html
@@ -49,9 +49,7 @@
     }
   }
   </script>
-  <script defer src="/_vercel/insights/script.js"></script>
-  <script defer src="/_vercel/speed-insights/script.js"></script>
-</head>
+    </head>
 <body class="bg-dark text-white overflow-hidden select-none">
 
   <canvas id="draw-canvas" style="position:fixed;top:0;left:0;width:100%;height:100%;z-index:0;display:block;touch-action:none;"></canvas>

--- a/index.html
+++ b/index.html
@@ -49,9 +49,7 @@
     }
   }
   </script>
-  <script defer src="/_vercel/insights/script.js"></script>
-  <script defer src="/_vercel/speed-insights/script.js"></script>
-</head>
+    </head>
 <body class="bg-dark text-white overflow-hidden select-none">
 
   <canvas id="game-canvas"></canvas>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,144 @@
+# Humans + agents welcome. Training crawlers + SEO scrapers blocked.
+
+# --- Allowed: search engines (send humans) ---
+User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: DuckDuckBot
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+# --- Allowed: agent browsers (user-initiated, send AI users) ---
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+# --- Allowed: dev/agent tooling we use ---
+User-agent: FirecrawlAgent
+Allow: /
+
+User-agent: firecrawl
+Allow: /
+
+User-agent: Context7Bot
+Allow: /
+
+User-agent: Crawl4AI
+Allow: /
+
+User-agent: Clawdbot
+Allow: /
+
+User-agent: OpenClaw
+Allow: /
+
+User-agent: Hermes
+Allow: /
+
+# --- Blocked: training crawlers ---
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: Meta-ExternalAgent
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: ImagesiftBot
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+User-agent: peer39_crawler
+Disallow: /
+
+User-agent: YouBot
+Disallow: /
+
+User-agent: Timpibot
+Disallow: /
+
+User-agent: ICC-Crawler
+Disallow: /
+
+# --- Blocked: SEO scrapers / link spammers ---
+User-agent: AhrefsBot
+Disallow: /
+
+User-agent: SemrushBot
+Disallow: /
+
+User-agent: MJ12bot
+Disallow: /
+
+User-agent: DotBot
+Disallow: /
+
+User-agent: PetalBot
+Disallow: /
+
+User-agent: BLEXBot
+Disallow: /
+
+User-agent: MegaIndex
+Disallow: /
+
+User-agent: SeznamBot
+Disallow: /
+
+User-agent: DataForSeoBot
+Disallow: /
+
+# --- Default: humans + everything else allowed ---
+User-agent: *
+Allow: /
+
+Sitemap: https://k8sgames.com/sitemap.xml

--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,12 @@
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800" }
       ]
+    },
+    {
+      "source": "/draw",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800" }
+      ]
     }
   ],
   "redirects": [

--- a/vercel.json
+++ b/vercel.json
@@ -37,7 +37,7 @@
   ],
   "redirects": [
     {
-      "source": "/:path*",
+      "source": "/((?!robots\\.txt$).*)",
       "has": [
         { "type": "header", "key": "user-agent", "value": "(?i).*(GPTBot|ClaudeBot|anthropic-ai|CCBot|Google-Extended|Applebot-Extended|Bytespider|Amazonbot|Meta-ExternalAgent|cohere-ai|Diffbot|ImagesiftBot|Omgilibot|peer39_crawler|YouBot|Timpibot|ICC-Crawler|AhrefsBot|SemrushBot|MJ12bot|DotBot|PetalBot|BLEXBot|MegaIndex|SeznamBot|DataForSeoBot).*"
         }

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,42 @@
   "rewrites": [
     { "source": "/draw", "destination": "/draw.html" }
   ],
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ':!README.md' ':!*.md' ':!LICENSE' ':!.github'"
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ':!README.md' ':!*.md' ':!LICENSE' ':!.github'",
+  "headers": [
+    {
+      "source": "/js/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=86400, s-maxage=604800, stale-while-revalidate=2592000" }
+      ]
+    },
+    {
+      "source": "/(.*)\\.(css|png|jpg|jpeg|svg|webp|woff2|woff|ttf|ico)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=86400, s-maxage=604800, stale-while-revalidate=2592000" }
+      ]
+    },
+    {
+      "source": "/(.*)\\.html",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800" }
+      ]
+    },
+    {
+      "source": "/",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800" }
+      ]
+    }
+  ],
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [
+        { "type": "header", "key": "user-agent", "value": "(?i).*(GPTBot|ClaudeBot|anthropic-ai|CCBot|Google-Extended|Applebot-Extended|Bytespider|Amazonbot|Meta-ExternalAgent|cohere-ai|Diffbot|ImagesiftBot|Omgilibot|peer39_crawler|YouBot|Timpibot|ICC-Crawler|AhrefsBot|SemrushBot|MJ12bot|DotBot|PetalBot|BLEXBot|MegaIndex|SeznamBot|DataForSeoBot).*"
+        }
+      ],
+      "destination": "/robots.txt",
+      "permanent": false
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Add `Cache-Control` headers to `vercel.json` for `/js/*` (31 JS files per pageview), assets, and HTML — returning visitors stop refetching
- Add `redirects` with `has` user-agent matcher: deflect known training and SEO bots to `/robots.txt` (saves bandwidth on the static payload)
- Add agent-aware `robots.txt`: explicit allow for search bots, user-initiated agent browsers, and dev tooling; disallow training crawlers and SEO scrapers
- Strip `/_vercel/insights/script.js` and `/_vercel/speed-insights/script.js` from `index.html` and `draw.html` — drops two edge requests per pageview and frees Web Analytics events budget

## Why
k8sgames is 70.7% of the Vercel project's edge-request volume (~2.1M req / 30d on hobby). Each pageview pulls 31 JS files + 2 Vercel insights scripts = 33+ edge req. Without cache headers every returning visitor hits edge again.

Site stays open to legitimate AI agents — Firecrawl, Context7, Crawl4AI, OpenClaw, Hermes, ChatGPT-User, Claude-User, PerplexityBot are explicitly allowed. Only model-training crawlers and SEO scrapers are denied.

## Bot policy
**Allowed:** Googlebot, Bingbot, DuckDuckBot, Applebot, ChatGPT-User, OAI-SearchBot, PerplexityBot, Perplexity-User, Claude-User, Claude-SearchBot, FirecrawlAgent, Context7Bot, Crawl4AI, Clawdbot, OpenClaw, Hermes — plus default `User-agent: *` allow.

**Disallowed:** GPTBot, ClaudeBot, anthropic-ai, CCBot, Google-Extended, Applebot-Extended, Bytespider, Amazonbot, Meta-ExternalAgent, cohere-ai, Diffbot, ImagesiftBot, Omgilibot, peer39_crawler, YouBot, Timpibot, ICC-Crawler, AhrefsBot, SemrushBot, MJ12bot, DotBot, PetalBot, BLEXBot, MegaIndex, SeznamBot, DataForSeoBot.

## Test plan
- [ ] Vercel preview build succeeds
- [ ] `/robots.txt` returns 200 with agent-aware content
- [ ] `/js/engine/*.js` response includes `Cache-Control: public, max-age=86400, ...`
- [ ] HTML response includes `Cache-Control: public, max-age=300, ...`
- [ ] Request with `User-Agent: SemrushBot` redirects to `/robots.txt`
- [ ] Request with `User-Agent: ChatGPT-User` serves the page normally
- [ ] No `_vercel/insights` or `_vercel/speed-insights` scripts in DOM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed third-party client tracking scripts from site headers to stop client-side execution of those integrations.
  * Added a robots.txt to manage crawler access, explicitly allow/deny listed bots and declare the site sitemap.
  * Implemented HTTP caching rules for JS, static assets and HTML pages, and added a conditional redirect routing identified crawler user-agents to the robots.txt configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->