### PR TITLE
Add unofficial Korean distribution

### DIFF
--- a/NOTICE-KO.md
+++ b/NOTICE-KO.md
@@ -1,0 +1,16 @@
+# K8s Games 한국어 배포판 고지
+
+이 저장소는 Rohit Ghumare의 K8s Games를 기반으로 만든 비공식 한국어 배포판입니다.
+
+- 원본 저장소: https://github.com/rohitg00/k8sgames
+- 원본 저작권: Copyright 2026 Rohit Ghumare
+- 원본 라이선스: Apache License, Version 2.0
+
+## 변경 사항
+
+- 한국어 UI/학습 콘텐츠 번역 레이어 추가
+- 메인 게임과 K8s Draw의 문서 언어 및 기본 표시 문구를 한국어로 변경
+- 한국어 폰트 설정 추가
+- 비공식 한국어 배포판임을 화면과 문서에 표시
+
+Apache-2.0 라이선스 전문은 `LICENSE` 파일에 포함되어 있습니다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,35 @@
+# K8s Games 한국어 배포판
+
+Kubernetes를 게임처럼 배울 수 있는 **K8s Games**의 비공식 한국어 배포판입니다. Pod를 배포하고, CrashLoopBackOff 같은 장애를 진단하고, 실제와 비슷한 `kubectl` 명령을 입력하며 클러스터 운영 감각을 익힐 수 있습니다.
+
+> 이 배포판은 원본 프로젝트의 공식 배포가 아닙니다. 원본은 [rohitg00/k8sgames](https://github.com/rohitg00/k8sgames)이며 Apache-2.0 라이선스로 배포됩니다.
+
+## 실행하기
+
+```bash
+python3 -m http.server 8080
+```
+
+브라우저에서 `http://localhost:8080`을 엽니다.
+
+## 한글화 범위
+
+- 메인 메뉴, 일부 HUD/도움말 문구
+- 캠페인 챕터명
+- 캠페인 레벨 제목 전체
+- 초반 캠페인 설명/목표/힌트
+- 챌린지 제목
+- K8s Draw 상단 도구막대 일부
+
+`Pod`, `Deployment`, `CrashLoopBackOff`, `kubectl` 출력 같은 Kubernetes 고유 용어와 명령어는 학습 효과를 위해 대부분 원문을 유지합니다.
+
+## 라이선스와 고지
+
+이 배포판은 원본의 Apache-2.0 라이선스를 따릅니다.
+
+- `LICENSE` 파일을 유지해야 합니다.
+- 원본 저작권 및 출처 표기를 유지해야 합니다.
+- 수정된 파일에는 변경 사실을 표시해야 합니다.
+- 이 배포판을 공식 K8s Games처럼 오인하게 만들면 안 됩니다.
+
+자세한 변경 고지는 `NOTICE-KO.md`를 참고하세요.

--- a/README.md
+++ b/README.md
@@ -1,104 +1,81 @@
-# K8s Games
+# K8s게임 한국어 패치버전
 
-> Unofficial Korean distribution work is tracked in `README.ko.md` and `NOTICE-KO.md`.
-> Modified distribution files retain the original Apache-2.0 license and attribution.
+Kubernetes를 게임처럼 배울 수 있는 **K8s Games**의 비공식 한국어 패치버전입니다. Pod를 배포하고, CrashLoopBackOff 같은 장애를 진단하고, 실제와 비슷한 `kubectl` 명령을 입력하면서 클러스터 운영 감각을 익힐 수 있습니다.
 
-Learn Kubernetes by playing. Deploy pods, fix CrashLoopBackOff, type real kubectl commands — all in a 3D sim that runs in your browser.
+> 이 저장소는 공식 K8s Games가 아닙니다. 원작자의 Apache-2.0 라이선스 프로젝트를 기반으로 한국어 번역과 배포 편의 패치를 더한 비공식 배포판입니다.
 
-**[Play Now at k8sgames.com](https://k8sgames.com)** | **[K8s Draw — 3D Architecture Diagrams](https://k8sgames.com/draw)**
+## 바로 실행
 
-![K8s Games — 3D Kubernetes cluster simulation in the browser](screenshot.png)
+- 한국어 패치버전: https://linux.m161awm.kr/k8sgames/
+- K8s Draw 한국어판: https://linux.m161awm.kr/k8sgames/draw.html
+- 원작자 저장소: https://github.com/rohitg00/k8sgames
+- 번역자 GitHub: https://github.com/m161awm2
 
-## Get Started
+![K8s Games - 3D Kubernetes cluster simulation in the browser](screenshot.png)
 
-Visit **[k8sgames.com](https://k8sgames.com)** and pick a mode. No install, no signup, no build step.
+## 로컬 실행
 
-Just here to diagram? Go straight to **[k8sgames.com/draw](https://k8sgames.com/draw)** — drag K8s resources onto a 3D canvas, draw connections, export YAML or PNG, and share via URL.
-
-Or run locally:
+별도 빌드가 필요 없는 정적 웹앱입니다.
 
 ```bash
-git clone https://github.com/rohitg00/k8sgames.git
+git clone https://github.com/m161awm2/k8sgames.git
 cd k8sgames
+git switch korean-distribution
 python3 -m http.server 8080
-# Open http://localhost:8080
 ```
 
-## How to Play
+브라우저에서 `http://localhost:8080`을 열면 됩니다.
 
-1. Pick a game mode from the main menu
-2. Click resources from the left palette to place them in your cluster
-3. Drag resources to reposition them anywhere
-4. Click any resource to inspect it (status, YAML, kubectl describe)
-5. Right-click for actions (Scale, Delete, Logs, Restart)
-6. Press `/` to open the kubectl command bar
-7. Handle incidents as they appear — diagnose and fix like a real SRE
-8. Press `?` anytime for help
+## 한글화 범위
 
-## Game Modes
+- 메인 메뉴와 주요 버튼
+- 캠페인 챕터명
+- 캠페인 레벨 제목 전체
+- 초반 캠페인 설명, 목표, 힌트
+- 챌린지 제목
+- K8s Draw 상단 도구막대 일부
+- 한국어 폰트 및 GitHub Pages 경로 패치
 
-| Mode | What You Do |
-|------|-------------|
-| **Campaign** | 20 levels across 5 chapters. Learn pods, deployments, networking, storage, and production K8s |
-| **Chaos** | Endless survival. Incidents escalate until your cluster breaks. How long can you last? |
-| **Sandbox** | Free build. Design any cluster, get scored 0-100 by the Architecture Advisor |
-| **Challenges** | 10 timed scenarios. Deploy apps, fix outages, race the clock |
+`Pod`, `Deployment`, `CrashLoopBackOff`, `kubectl` 출력 같은 Kubernetes 고유 용어와 명령어는 학습 효과를 위해 상당 부분 원문을 유지합니다.
 
-### K8s Draw (`/draw`)
+## 게임 모드
 
-A 3D Kubernetes architecture whiteboard. Like Excalidraw but for K8s.
+| 모드 | 설명 |
+|------|------|
+| 캠페인 | 5개 챕터, 20개 레벨로 Kubernetes 기본부터 프로덕션 운영까지 학습 |
+| 카오스 모드 | 점점 강해지는 장애를 버티는 생존형 SRE 훈련 |
+| 샌드박스 | 자유롭게 클러스터를 설계하고 아키텍처 점수를 확인 |
+| 챌린지 | 시간 제한 시나리오에서 앱 배포와 장애 복구 수행 |
 
-- Drag-drop 21 resource types onto a 3D canvas
-- Draw connection lines between resources
-- Double-click to rename any resource
-- Auto-layout organizes by tier (Nodes, Workloads, Networking, Storage, RBAC)
-- Export as YAML (with correct apiVersions) or PNG
-- Share diagrams via URL — one-click copy, open anywhere
-- Edit properties: name, namespace, labels, replicas
-- Right-click to delete, `Del` key for selected
+## K8s Draw
 
-No game logic, no incidents, no scoring — just diagramming.
+Kubernetes 아키텍처를 3D로 그리는 다이어그램 도구입니다.
 
-## Controls
+- K8s 리소스를 3D 캔버스에 배치
+- 리소스 간 연결선 작성
+- 리소스 이름, namespace, label, replica 편집
+- YAML 또는 PNG로 내보내기
+- URL로 다이어그램 공유
 
-| Input | Action |
-|-------|--------|
-| `/` | kubectl command bar |
-| `?` | Help / How to play |
-| `Space` | Pause / Resume |
-| `M` | Metrics dashboard |
-| `Esc` | Back to menu |
-| `1-9` | Quick-select resource |
-| Left-click | Select resource |
-| Left-drag | Move resource or rotate camera |
-| Right-click | Context menu |
-| Right-drag | Pan |
-| Scroll | Zoom |
+## 조작법
 
-Bottom toolbar: **Auto-Align** (K8s architecture layout) | **Reset View** | **YAML** (export cluster) | **Help**
+| 입력 | 동작 |
+|------|------|
+| `/` | kubectl 명령창 열기 |
+| `?` | 도움말 |
+| `Space` | 일시정지 / 재개 |
+| `M` | 메트릭 대시보드 |
+| `Esc` | 메뉴로 돌아가기 |
+| `1-9` | 리소스 빠른 선택 |
+| 왼쪽 클릭 | 리소스 선택 |
+| 오른쪽 클릭 | 컨텍스트 메뉴 |
+| 스크롤 | 확대 / 축소 |
 
-## What's In It
+## 출처와 라이선스
 
-**25 K8s resources** — Pod, Deployment, ReplicaSet, StatefulSet, DaemonSet, Job, CronJob, Service, Ingress, NetworkPolicy, ConfigMap, Secret, PVC, PV, StorageClass, Node, Namespace, HPA, ResourceQuota, PodDisruptionBudget, ServiceAccount, Role, ClusterRole, RoleBinding, ClusterRoleBinding. Each has a unique 3D shape, color, and real K8s behavior.
+- 원작자: Rohit Ghumare
+- 원본 저장소: https://github.com/rohitg00/k8sgames
+- 한국어 번역/패치: https://github.com/m161awm2
+- 라이선스: Apache License 2.0
 
-**29 incidents** — OOMKilled, CrashLoopBackOff, ImagePullBackOff, node NotReady, DNS failures, PVC pending, API throttling, rollout stuck, certificate expiry, HPA flapping, and more. Investigate with kubectl describe/logs, then fix.
-
-**kubectl command bar** — type real commands: `get pods`, `describe deployment nginx`, `scale deployment nginx --replicas=3`, `logs pod-1`, `rollout status`, `drain node-1`. Tab completion included.
-
-**Visual connections** — animated lines show ownership chains (Deployment -> ReplicaSet -> Pod) and network routing (Service -> Pods) based on label selectors. Place a Service and pick which Deployment it connects to.
-
-**Edit resources** — click Edit on any resource to modify labels, replicas, selectors, and service types. Quick-connect buttons let you wire a Service to an existing Deployment in one click.
-
-**Architecture Advisor** — scores your cluster design across HA, security, scalability, cost, and 6 other categories.
-
-**40 achievements** and a 30-level XP system from Novice to CKA-ready.
-
-**RBAC simulation** — ServiceAccounts, Roles, ClusterRoles, RoleBindings, and ClusterRoleBindings with real rule definitions and wildcard detection.
-
-## Tech
-
-Three.js r152 + Tailwind CSS CDN + vanilla ES6 modules. No build step, no dependencies, no bundler. ~50K lines across 90+ files.
-
-## License
-
-Apache-2.0
+Apache-2.0 라이선스 전문은 `LICENSE` 파일에 포함되어 있습니다. 한국어 배포판 변경 고지는 `NOTICE-KO.md`를 참고하세요.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # K8s Games
 
+> Unofficial Korean distribution work is tracked in `README.ko.md` and `NOTICE-KO.md`.
+> Modified distribution files retain the original Apache-2.0 license and attribution.
+
 Learn Kubernetes by playing. Deploy pods, fix CrashLoopBackOff, type real kubectl commands — all in a 3D sim that runs in your browser.
 
 **[Play Now at k8sgames.com](https://k8sgames.com)** | **[K8s Draw — 3D Architecture Diagrams](https://k8sgames.com/draw)**

--- a/draw.html
+++ b/draw.html
@@ -66,7 +66,7 @@
     </div>
     <div class="flex items-center gap-2 overflow-x-auto scrollbar-none">
       <span id="draw-status" class="text-xs text-sky-400 mr-2 draw-status-text"></span>
-      <button id="btn-connect" class="draw-btn shrink-0 px-3 py-1.5 text-xs text-white/60 hover:text-white bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg transition-all" title="Draw a line between two resources: click source, then click target">
+      <button id="btn-connect" class="draw-btn shrink-0 px-3 py-1.5 text-xs text-white/60 hover:text-white bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg transition-all" title="두 리소스 사이에 연결선을 그립니다. 시작 리소스와 대상 리소스를 차례로 클릭하세요">
         <svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/></svg><span class="draw-btn-label">연결선</span>
       </button>
       <button id="btn-auto-layout" class="draw-btn shrink-0 px-3 py-1.5 text-xs text-white/60 hover:text-white bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg transition-all"><span class="draw-btn-label">자동 배치</span><span class="draw-btn-icon-only hidden"><svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"/></svg></span></button>
@@ -82,7 +82,7 @@
   </div>
 
   <div id="resource-palette" class="glass-dark">
-    <div class="palette-section-label">Workloads</div>
+    <div class="palette-section-label">Workload</div>
 
     <div class="palette-item" data-resource="Pod" draggable="true">
       <div class="palette-icon">
@@ -141,7 +141,7 @@
     </div>
 
     <div class="palette-separator"></div>
-    <div class="palette-section-label">Network</div>
+    <div class="palette-section-label">네트워크</div>
 
     <div class="palette-item" data-resource="Service" draggable="true">
       <div class="palette-icon">
@@ -168,7 +168,7 @@
     </div>
 
     <div class="palette-separator"></div>
-    <div class="palette-section-label">Config</div>
+    <div class="palette-section-label">설정</div>
 
     <div class="palette-item" data-resource="ConfigMap" draggable="true">
       <div class="palette-icon">
@@ -187,7 +187,7 @@
     </div>
 
     <div class="palette-separator"></div>
-    <div class="palette-section-label">Storage</div>
+    <div class="palette-section-label">스토리지</div>
 
     <div class="palette-item" data-resource="PersistentVolumeClaim" draggable="true">
       <div class="palette-icon">
@@ -198,7 +198,7 @@
     </div>
 
     <div class="palette-separator"></div>
-    <div class="palette-section-label">Cluster</div>
+    <div class="palette-section-label">클러스터</div>
 
     <div class="palette-item" data-resource="Node" draggable="true">
       <div class="palette-icon">
@@ -262,20 +262,20 @@
 
   <div id="draw-props" class="fixed right-0 top-12 z-30 backdrop-blur-xl bg-black/70 border-l border-white/10 overflow-y-auto transition-transform duration-300 translate-x-full" style="bottom:0;width:18rem;">
     <div class="flex items-center justify-between px-4 py-3 border-b border-white/10">
-      <span class="text-sm font-semibold text-white/90">Properties</span>
+      <span class="text-sm font-semibold text-white/90">속성</span>
       <button id="btn-close-props" class="text-white/40 hover:text-white/80 text-xs transition-colors">&#10005;</button>
     </div>
     <div id="props-body" class="p-4 space-y-4 text-xs">
-      <div class="text-white/30 text-center py-8">Select a resource to edit properties</div>
+      <div class="text-white/30 text-center py-8">속성을 편집할 리소스를 선택하세요</div>
     </div>
   </div>
 
   <div id="draw-help" class="fixed bottom-4 left-20 z-30 px-3 py-2 text-[10px] text-white/20 space-y-0.5">
-    <div>Drag resources from palette to canvas</div>
-    <div>Double-click resource to rename</div>
-    <div>Click <strong class="text-white/40">Draw Line</strong> then click two resources to link</div>
-    <div>Right-click resource to delete</div>
-    <div><kbd class="px-1 bg-white/5 rounded">Esc</kbd> cancel &middot; <kbd class="px-1 bg-white/5 rounded">Del</kbd> delete selected</div>
+    <div>팔레트에서 캔버스로 리소스를 드래그하세요</div>
+    <div>리소스를 더블클릭하면 이름을 바꿀 수 있습니다</div>
+    <div><strong class="text-white/40">연결선</strong>을 누른 뒤 리소스 두 개를 클릭해 연결하세요</div>
+    <div>리소스를 우클릭하면 삭제할 수 있습니다</div>
+    <div><kbd class="px-1 bg-white/5 rounded">Esc</kbd> 취소 &middot; <kbd class="px-1 bg-white/5 rounded">Del</kbd> 선택 항목 삭제</div>
   </div>
 
   <div id="draw-watermark" class="fixed bottom-4 left-1/2 -translate-x-1/2 z-30 flex items-center gap-2 text-[10px] text-white/15">
@@ -726,11 +726,11 @@
         body.innerHTML = `
           <div class="space-y-3">
             <div>
-              <label class="block text-white/40 mb-1">Kind</label>
+              <label class="block text-white/40 mb-1">종류</label>
               <div class="px-2 py-1.5 bg-white/5 border border-white/10 rounded text-white/70">${this._esc(resource.kind)}</div>
             </div>
             <div>
-              <label class="block text-white/40 mb-1">Name</label>
+              <label class="block text-white/40 mb-1">이름</label>
               <input id="prop-name" type="text" class="w-full px-2 py-1.5 bg-white/5 border border-white/10 rounded text-white/90 outline-none focus:border-sky-500/40 transition-colors" />
             </div>
             <div>
@@ -738,16 +738,16 @@
               <input id="prop-namespace" type="text" class="w-full px-2 py-1.5 bg-white/5 border border-white/10 rounded text-white/90 outline-none focus:border-sky-500/40 transition-colors" />
             </div>
             <div>
-              <label class="block text-white/40 mb-1">Labels <span class="text-white/20">(key=value per line)</span></label>
+              <label class="block text-white/40 mb-1">레이블 <span class="text-white/20">(한 줄에 key=value)</span></label>
               <textarea id="prop-labels" rows="3" class="w-full px-2 py-1.5 bg-white/5 border border-white/10 rounded text-white/90 outline-none focus:border-sky-500/40 transition-colors font-mono text-[11px] resize-none"></textarea>
             </div>
             ${resource.spec?.replicas !== undefined ? `
             <div>
-              <label class="block text-white/40 mb-1">Replicas</label>
+              <label class="block text-white/40 mb-1">Replica</label>
               <input id="prop-replicas" type="number" min="0" max="100" class="w-full px-2 py-1.5 bg-white/5 border border-white/10 rounded text-white/90 outline-none focus:border-sky-500/40 transition-colors" />
             </div>` : ''}
-            <button id="prop-apply" class="w-full px-3 py-2 text-xs font-medium text-white bg-sky-500/20 hover:bg-sky-500/30 border border-sky-500/30 rounded-lg transition-all">Apply Changes</button>
-            <button id="prop-delete" class="w-full px-3 py-2 text-xs font-medium text-red-400 bg-red-500/10 hover:bg-red-500/20 border border-red-500/20 rounded-lg transition-all">Delete Resource</button>
+            <button id="prop-apply" class="w-full px-3 py-2 text-xs font-medium text-white bg-sky-500/20 hover:bg-sky-500/30 border border-sky-500/30 rounded-lg transition-all">변경 적용</button>
+            <button id="prop-delete" class="w-full px-3 py-2 text-xs font-medium text-red-400 bg-red-500/10 hover:bg-red-500/20 border border-red-500/20 rounded-lg transition-all">리소스 삭제</button>
           </div>
         `;
 

--- a/draw.html
+++ b/draw.html
@@ -57,7 +57,7 @@
 
   <div id="draw-toolbar" class="fixed top-0 left-0 right-0 z-40 flex items-center justify-between px-4 py-2 backdrop-blur-xl bg-white/5 border-b border-white/10" style="height:48px;">
     <div class="flex items-center gap-3 shrink-0">
-      <a href="/" class="flex items-center gap-2 text-white/60 hover:text-white/90 transition-colors">
+      <a href="./" class="flex items-center gap-2 text-white/60 hover:text-white/90 transition-colors">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/></svg>
       </a>
       <div class="h-5 w-px bg-white/10"></div>
@@ -937,7 +937,7 @@
         try {
           const json = JSON.stringify(state);
           const encoded = btoa(new TextEncoder().encode(json).reduce((s, b) => s + String.fromCharCode(b), ''));
-          const url = `${window.location.origin}/draw#${encoded}`;
+          const url = `${window.location.href.split('#')[0]}#${encoded}`;
           navigator.clipboard.writeText(url).then(() => {
             const btn = document.getElementById('btn-share');
             const original = btn.innerHTML;

--- a/draw.html
+++ b/draw.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
+<!-- Modified for an unofficial Korean distribution. Original project: K8s Games by Rohit Ghumare, Apache-2.0. -->
+<html lang="ko">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>K8s Draw — 3D Kubernetes Architecture Diagram</title>
-  <meta name="description" content="Design Kubernetes architectures visually in 3D. Drag resources, draw connections, export YAML.">
+  <title>K8s Draw 한국어 배포판 — 3D Kubernetes 아키텍처 다이어그램</title>
+  <meta name="description" content="Kubernetes 아키텍처를 3D로 시각화하세요. 리소스를 배치하고, 연결선을 그리고, YAML로 내보냅니다.">
   <meta property="og:title" content="K8s Draw — 3D Kubernetes Architecture Diagram">
   <meta property="og:description" content="Design Kubernetes architectures visually in 3D. Drag resources, draw connections, export YAML. No install needed.">
   <meta property="og:type" content="website">
@@ -19,7 +20,7 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='14' fill='%23326CE5'/><text x='16' y='21' text-anchor='middle' fill='white' font-size='14' font-weight='bold'>K</text></svg>">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&family=Noto+Sans+KR:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com/3.4.1"></script>
   <script>
     tailwind.config = {
@@ -33,7 +34,7 @@
             'elevated': '#1c2333',
           },
           fontFamily: {
-            sans: ['Inter', 'system-ui', 'sans-serif'],
+            sans: ['Inter', 'Noto Sans KR', 'system-ui', 'sans-serif'],
             mono: ['JetBrains Mono', 'SF Mono', 'monospace'],
           }
         }
@@ -61,22 +62,22 @@
       </a>
       <div class="h-5 w-px bg-white/10"></div>
       <span class="text-white/90 text-sm font-semibold">K8s Draw</span>
-      <span class="draw-subtitle text-white/30 text-xs">3D Architecture Diagram</span>
+      <span class="draw-subtitle text-white/30 text-xs">3D 아키텍처 다이어그램 · 비공식 한국어 배포판</span>
     </div>
     <div class="flex items-center gap-2 overflow-x-auto scrollbar-none">
       <span id="draw-status" class="text-xs text-sky-400 mr-2 draw-status-text"></span>
       <button id="btn-connect" class="draw-btn shrink-0 px-3 py-1.5 text-xs text-white/60 hover:text-white bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg transition-all" title="Draw a line between two resources: click source, then click target">
-        <svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/></svg><span class="draw-btn-label">Draw Line</span>
+        <svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/></svg><span class="draw-btn-label">연결선</span>
       </button>
-      <button id="btn-auto-layout" class="draw-btn shrink-0 px-3 py-1.5 text-xs text-white/60 hover:text-white bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg transition-all"><span class="draw-btn-label">Auto-Layout</span><span class="draw-btn-icon-only hidden"><svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"/></svg></span></button>
+      <button id="btn-auto-layout" class="draw-btn shrink-0 px-3 py-1.5 text-xs text-white/60 hover:text-white bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg transition-all"><span class="draw-btn-label">자동 배치</span><span class="draw-btn-icon-only hidden"><svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"/></svg></span></button>
       <div class="draw-divider h-5 w-px bg-white/10"></div>
       <button id="btn-export-yaml" class="draw-btn shrink-0 px-3 py-1.5 text-xs text-white/60 hover:text-white bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg transition-all">YAML</button>
       <button id="btn-export-png" class="draw-btn shrink-0 px-3 py-1.5 text-xs text-white/60 hover:text-white bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg transition-all">PNG</button>
       <button id="btn-share" class="draw-btn shrink-0 px-3 py-1.5 text-xs text-white/60 hover:text-white bg-sky-500/10 hover:bg-sky-500/20 border border-sky-500/20 rounded-lg transition-all">
-        <svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"/></svg><span class="draw-btn-label">Share</span>
+        <svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"/></svg><span class="draw-btn-label">공유</span>
       </button>
       <div class="draw-divider h-5 w-px bg-white/10"></div>
-      <button id="btn-clear" class="draw-btn shrink-0 px-3 py-1.5 text-xs text-red-400/60 hover:text-red-400 bg-white/5 hover:bg-red-500/10 border border-white/10 hover:border-red-500/20 rounded-lg transition-all">Clear</button>
+      <button id="btn-clear" class="draw-btn shrink-0 px-3 py-1.5 text-xs text-red-400/60 hover:text-red-400 bg-white/5 hover:bg-red-500/10 border border-white/10 hover:border-red-500/20 rounded-lg transition-all">초기화</button>
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
       </button>
     </div>
 
-    <a href="/draw" class="menu-draw-link">
+    <a href="draw.html" class="menu-draw-link">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
       <span>K8s Draw</span>
       <span class="menu-draw-desc">Design K8s architectures in 3D. Drag resources, draw connections, export YAML.</span>

--- a/index.html
+++ b/index.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
+<!-- Modified for an unofficial Korean distribution. Original project: K8s Games by Rohit Ghumare, Apache-2.0. -->
+<html lang="ko">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>K8s Games - Kubernetes Cluster Management Simulation</title>
-  <meta name="description" content="Learn Kubernetes through interactive gameplay. Deploy pods, handle incidents, master kubectl commands.">
+  <title>K8s Games 한국어 배포판 - Kubernetes 클러스터 시뮬레이션</title>
+  <meta name="description" content="게임으로 Kubernetes를 배워보세요. Pod를 배포하고, 장애를 처리하고, kubectl 명령을 익힙니다.">
   <meta property="og:title" content="K8s Games - Learn Kubernetes by Playing">
   <meta property="og:description" content="Deploy pods, fix CrashLoopBackOff, type real kubectl commands — all in a 3D simulation that runs in your browser. No install needed.">
   <meta property="og:type" content="website">
@@ -19,7 +20,7 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='14' fill='%23326CE5'/><text x='16' y='21' text-anchor='middle' fill='white' font-size='14' font-weight='bold'>K</text></svg>">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&family=Noto+Sans+KR:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com/3.4.1"></script>
   <script>
     tailwind.config = {
@@ -33,7 +34,7 @@
             'elevated': '#1c2333',
           },
           fontFamily: {
-            sans: ['Inter', 'system-ui', 'sans-serif'],
+            sans: ['Inter', 'Noto Sans KR', 'system-ui', 'sans-serif'],
             mono: ['JetBrains Mono', 'SF Mono', 'monospace'],
           }
         }
@@ -56,7 +57,8 @@
 
   <div id="main-menu">
     <div class="menu-logo">K8s Games</div>
-    <div class="menu-subtitle">Kubernetes Cluster Simulation</div>
+    <div class="menu-subtitle">Kubernetes 클러스터 시뮬레이션</div>
+    <div class="menu-subtitle" style="margin-top:.35rem;font-size:.78rem;color:rgba(255,255,255,.45);">비공식 한국어 배포판</div>
 
     <a href="https://github.com/rohitg00/k8sgames" target="_blank" rel="noopener" class="github-badge" id="github-badge">
       <div class="github-badge-inner">
@@ -452,6 +454,9 @@
     import { PersistentVolume, StorageClass, PersistentVolumeClaim } from './js/resources/StorageResources.js';
     import { Node, Namespace, HorizontalPodAutoscaler, ResourceQuota, PodDisruptionBudget } from './js/resources/ClusterResources.js';
     import { ServiceAccount, Role, ClusterRole, RoleBinding, ClusterRoleBinding } from './js/resources/RBACResources.js';
+    import { applyKoreanLocale } from './js/i18n/ko.js';
+
+    applyKoreanLocale({ CAMPAIGN_LEVELS, CHAPTERS, ACHIEVEMENTS, CHALLENGES });
 
     const RESOURCE_CLASSES = {
       Pod, Deployment, ReplicaSet, StatefulSet, DaemonSet, Job, CronJob,

--- a/index.html
+++ b/index.html
@@ -58,7 +58,12 @@
   <div id="main-menu">
     <div class="menu-logo">K8s Games</div>
     <div class="menu-subtitle">Kubernetes 클러스터 시뮬레이션</div>
-    <div class="menu-subtitle" style="margin-top:.35rem;font-size:.78rem;color:rgba(255,255,255,.45);">비공식 한국어 배포판</div>
+    <div class="menu-subtitle" style="margin-top:.35rem;font-size:.78rem;color:rgba(255,255,255,.45);">K8s게임 한국어 패치버전</div>
+    <div class="menu-attribution" style="display:flex;justify-content:center;align-items:center;gap:.75rem;flex-wrap:wrap;margin-top:.8rem;font-size:.72rem;color:rgba(255,255,255,.5);">
+      <a href="https://github.com/rohitg00/k8sgames" target="_blank" rel="noopener" style="color:rgba(88,166,255,.9);text-decoration:none;border-bottom:1px solid rgba(88,166,255,.25);">원작자 repo: rohitg00/k8sgames</a>
+      <span style="color:rgba(255,255,255,.22);">|</span>
+      <a href="https://github.com/m161awm2" target="_blank" rel="noopener" style="color:rgba(88,166,255,.9);text-decoration:none;border-bottom:1px solid rgba(88,166,255,.25);">번역: m161awm2</a>
+    </div>
 
     <a href="https://github.com/rohitg00/k8sgames" target="_blank" rel="noopener" class="github-badge" id="github-badge">
       <div class="github-badge-inner">

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
         <svg class="github-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
         </svg>
-        <span class="github-text">Star on GitHub</span>
+        <span class="github-text">원작자 GitHub</span>
         <span class="github-stars" id="github-stars">
           <svg class="github-star-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z"/></svg>
           <span id="github-star-count">--</span>
@@ -81,47 +81,47 @@
     <div class="menu-grid">
       <button class="menu-btn" data-mode="campaign">
         <span class="menu-btn-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polygon points="5 3 19 12 5 21 5 3"/></svg></span>
-        <div class="menu-btn-title">Campaign</div>
-        <div class="menu-btn-desc">20 levels from pods to production. Learn K8s step by step.</div>
+        <div class="menu-btn-title">캠페인</div>
+        <div class="menu-btn-desc">Pod부터 프로덕션까지 20개 레벨로 단계별 학습</div>
       </button>
       <button class="menu-btn" data-mode="chaos">
         <span class="menu-btn-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></span>
-        <div class="menu-btn-title">Chaos Mode</div>
-        <div class="menu-btn-desc">Survive escalating incidents. SRE training at its finest.</div>
+        <div class="menu-btn-title">카오스 모드</div>
+        <div class="menu-btn-desc">점점 커지는 incident를 버티는 SRE 훈련</div>
       </button>
       <button class="menu-btn" data-mode="sandbox">
         <span class="menu-btn-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></span>
-        <div class="menu-btn-title">Sandbox</div>
-        <div class="menu-btn-desc">Free cluster management. Design, build, get scored.</div>
+        <div class="menu-btn-title">샌드박스</div>
+        <div class="menu-btn-desc">자유롭게 클러스터를 설계하고 점수를 확인</div>
       </button>
       <button class="menu-btn" data-mode="challenge">
         <span class="menu-btn-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg></span>
-        <div class="menu-btn-title">Challenges</div>
-        <div class="menu-btn-desc">10 timed scenarios. Fix outages, deploy apps, race the clock.</div>
+        <div class="menu-btn-title">챌린지</div>
+        <div class="menu-btn-desc">10개의 시간 제한 시나리오에서 장애를 해결</div>
       </button>
     </div>
 
     <a href="draw.html" class="menu-draw-link">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
       <span>K8s Draw</span>
-      <span class="menu-draw-desc">Design K8s architectures in 3D. Drag resources, draw connections, export YAML.</span>
+      <span class="menu-draw-desc">3D로 K8s 아키텍처를 설계하고 YAML로 내보내기</span>
     </a>
 
     <div class="menu-footer">
-      <button class="menu-footer-btn" id="btn-settings">Settings</button>
-      <button class="menu-footer-btn" id="btn-achievements">Achievements</button>
-      <button class="menu-footer-btn" id="btn-stats">Stats</button>
+      <button class="menu-footer-btn" id="btn-settings">설정</button>
+      <button class="menu-footer-btn" id="btn-achievements">업적</button>
+      <button class="menu-footer-btn" id="btn-stats">통계</button>
     </div>
 
     <div id="menu-hints" style="margin-top: 2rem; text-align: center; max-width: 100%; overflow: hidden;">
       <div class="menu-keyboard-hints" style="font-size: 0.7rem; color: var(--text-muted);">
-        Press <span class="keyboard-hint">/</span> for kubectl &middot;
-        <span class="keyboard-hint">Space</span> pause &middot;
+        <span class="keyboard-hint">/</span> kubectl &middot;
+        <span class="keyboard-hint">Space</span> 일시정지 &middot;
         <span class="keyboard-hint">M</span> metrics &middot;
-        <span class="keyboard-hint">Esc</span> menu
+        <span class="keyboard-hint">Esc</span> 메뉴
       </div>
       <div style="margin-top: 1rem; font-size: 0.7rem; color: rgba(255,255,255,0.25);">
-        made with <span style="color: #ef4444;">&hearts;</span> by <a href="https://x.com/ghumare64" target="_blank" rel="noopener" style="color: rgba(255,255,255,0.45); text-decoration: none; border-bottom: 1px solid rgba(255,255,255,0.15); transition: color 0.2s;" onmouseover="this.style.color='#58a6ff'" onmouseout="this.style.color='rgba(255,255,255,0.45)'">Rohit</a>
+        원작자 <a href="https://github.com/rohitg00/k8sgames" target="_blank" rel="noopener" style="color: rgba(255,255,255,0.45); text-decoration: none; border-bottom: 1px solid rgba(255,255,255,0.15); transition: color 0.2s;" onmouseover="this.style.color='#58a6ff'" onmouseout="this.style.color='rgba(255,255,255,0.45)'">Rohit</a> · 번역 <a href="https://github.com/m161awm2" target="_blank" rel="noopener" style="color: rgba(255,255,255,0.45); text-decoration: none; border-bottom: 1px solid rgba(255,255,255,0.15); transition: color 0.2s;" onmouseover="this.style.color='#58a6ff'" onmouseout="this.style.color='rgba(255,255,255,0.45)'">m161awm2</a>
       </div>
     </div>
   </div>
@@ -333,8 +333,8 @@
   <div id="level-select">
     <div style="max-width: 650px; width: 95%;">
       <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 1.5rem;">
-        <h2 class="text-xl font-bold text-white">Campaign Levels</h2>
-        <button id="level-select-back" class="btn-secondary text-sm">Back</button>
+        <h2 class="text-xl font-bold text-white">캠페인 레벨</h2>
+        <button id="level-select-back" class="btn-secondary text-sm">뒤로</button>
       </div>
       <div class="level-grid" id="level-grid"></div>
     </div>
@@ -343,8 +343,8 @@
   <div id="challenge-select" class="modal-overlay">
     <div class="modal-content" style="max-width: 550px;">
       <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem;">
-        <h2 class="modal-title" style="margin-bottom:0">Challenges</h2>
-        <button id="challenge-back" class="btn-secondary text-sm">Back</button>
+        <h2 class="modal-title" style="margin-bottom:0">챌린지</h2>
+        <button id="challenge-back" class="btn-secondary text-sm">뒤로</button>
       </div>
       <div class="challenge-grid" id="challenge-grid"></div>
     </div>
@@ -353,32 +353,32 @@
   <div id="settings-panel" class="settings-panel">
     <div class="settings-content">
       <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 1.5rem;">
-        <h2 class="text-lg font-bold">Settings</h2>
-        <button id="settings-close" class="btn-secondary text-sm">Close</button>
+        <h2 class="text-lg font-bold">설정</h2>
+        <button id="settings-close" class="btn-secondary text-sm">닫기</button>
       </div>
       <div class="settings-row">
-        <span class="settings-label">Sound Effects</span>
+        <span class="settings-label">효과음</span>
         <button class="toggle active" id="toggle-sound"></button>
       </div>
       <div class="settings-row">
-        <span class="settings-label">Particles</span>
+        <span class="settings-label">파티클</span>
         <button class="toggle active" id="toggle-particles"></button>
       </div>
       <div class="settings-row">
-        <span class="settings-label">Shadows</span>
+        <span class="settings-label">그림자</span>
         <button class="toggle active" id="toggle-shadows"></button>
       </div>
       <div class="settings-row">
-        <span class="settings-label">Grid</span>
+        <span class="settings-label">그리드</span>
         <button class="toggle active" id="toggle-grid"></button>
       </div>
       <div class="settings-row" style="border-bottom: none;">
-        <span class="settings-label">Difficulty</span>
+        <span class="settings-label">난이도</span>
         <select id="select-difficulty" class="bg-dark border border-white/10 rounded px-2 py-1 text-sm text-white/80 outline-none">
-          <option value="easy">Easy</option>
-          <option value="normal" selected>Normal</option>
-          <option value="hard">Hard</option>
-          <option value="nightmare">Nightmare</option>
+          <option value="easy">쉬움</option>
+          <option value="normal" selected>보통</option>
+          <option value="hard">어려움</option>
+          <option value="nightmare">악몽</option>
         </select>
       </div>
     </div>
@@ -387,8 +387,8 @@
   <div id="achievements-panel" class="modal-overlay">
     <div class="modal-content" style="max-width: 600px;">
       <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem;">
-        <h2 class="modal-title" style="margin-bottom:0">Achievements</h2>
-        <button id="achievements-close" class="btn-secondary text-sm">Close</button>
+        <h2 class="modal-title" style="margin-bottom:0">업적</h2>
+        <button id="achievements-close" class="btn-secondary text-sm">닫기</button>
       </div>
       <div class="achievements-grid" id="achievements-grid"></div>
     </div>
@@ -397,8 +397,8 @@
   <div id="stats-panel" class="modal-overlay">
     <div class="modal-content">
       <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem;">
-        <h2 class="modal-title" style="margin-bottom:0">Statistics</h2>
-        <button id="stats-close" class="btn-secondary text-sm">Close</button>
+        <h2 class="modal-title" style="margin-bottom:0">통계</h2>
+        <button id="stats-close" class="btn-secondary text-sm">닫기</button>
       </div>
       <div id="stats-body" class="modal-body"></div>
     </div>
@@ -407,11 +407,11 @@
   <div id="modal-level-complete" class="modal-overlay">
     <div class="modal-content" style="text-align: center;">
       <div class="text-3xl mb-2" id="level-complete-stars"></div>
-      <h2 class="modal-title" id="level-complete-title">Level Complete!</h2>
+      <h2 class="modal-title" id="level-complete-title">레벨 완료!</h2>
       <div class="modal-body" id="level-complete-body"></div>
       <div class="modal-actions" style="justify-content: center;">
-        <button class="btn-secondary" id="level-complete-menu">Menu</button>
-        <button class="btn-primary" id="level-complete-next">Next Level</button>
+        <button class="btn-secondary" id="level-complete-menu">메뉴</button>
+        <button class="btn-primary" id="level-complete-next">다음 레벨</button>
       </div>
     </div>
   </div>
@@ -419,18 +419,18 @@
   <div id="modal-game-over" class="modal-overlay">
     <div class="modal-content" style="text-align: center;">
       <div class="text-4xl mb-3">&#128165;</div>
-      <h2 class="modal-title">Cluster Down!</h2>
+      <h2 class="modal-title">클러스터 다운!</h2>
       <div class="modal-body" id="game-over-body"></div>
       <div class="modal-actions" style="justify-content: center;">
-        <button class="btn-secondary" id="game-over-menu">Menu</button>
-        <button class="btn-primary" id="game-over-retry">Retry</button>
+        <button class="btn-secondary" id="game-over-menu">메뉴</button>
+        <button class="btn-primary" id="game-over-retry">다시 시도</button>
       </div>
     </div>
   </div>
 
   <div id="loading-screen" class="loading-screen" style="display: none;">
     <div class="loading-spinner"></div>
-    <div class="loading-text">Initializing cluster...</div>
+    <div class="loading-text">클러스터 초기화 중...</div>
   </div>
 
   <script type="module">
@@ -1568,7 +1568,7 @@
               hintBtn.style.display = 'none';
             } else {
               const label = hintBtn.querySelector('span');
-              if (label) label.textContent = `Show Hint (${allHints.length - this._hintIndex} left)`;
+              if (label) label.textContent = `힌트 보기 (${allHints.length - this._hintIndex}개 남음)`;
             }
           }
         };
@@ -1594,7 +1594,7 @@
           const secs = (status.timeRemaining || 0) % 60;
           const timeStr = `${mins}:${String(secs).padStart(2, '0')}`;
           const urgentClass = (status.timeRemaining || 0) <= 30 ? 'text-red-400' : 'text-sky-400';
-          titleEl.innerHTML = `<span class="truncate">${status.title || 'Challenge'}</span><span class="${urgentClass} font-mono text-[11px] ml-auto pl-2 shrink-0">${timeStr}</span>`;
+          titleEl.innerHTML = `<span class="truncate">${status.title || '챌린지'}</span><span class="${urgentClass} font-mono text-[11px] ml-auto pl-2 shrink-0">${timeStr}</span>`;
         } else {
           titleEl.textContent = `L${status.currentLevel || '?'} - ${status.levelTitle || ''}`;
         }
@@ -1719,58 +1719,58 @@
         const existing = document.getElementById('tutorial-overlay');
         if (existing) existing.remove();
 
-        const modeNames = { sandbox: 'Sandbox Mode', chaos: 'Chaos Mode', campaign: 'Campaign', challenge: 'Challenge' };
+        const modeNames = { sandbox: '샌드박스', chaos: '카오스 모드', campaign: '캠페인', challenge: '챌린지' };
 
         const modeGoals = {
-            sandbox: 'Build any cluster you want. The Architecture Advisor scores your design 0-100 across HA, security, scalability, and cost.',
-            chaos: 'Survive as long as possible. Incidents escalate over time. If cluster health hits zero, game over. Fix issues fast for combo XP.',
-            campaign: 'Complete objectives to pass each level. Faster completion with fewer resources earns more stars (3 max).',
-            challenge: 'Beat the clock. Deploy and configure the required resources before time runs out.',
+            sandbox: '원하는 클러스터를 자유롭게 만드세요. Architecture Advisor가 HA, 보안, 확장성, 비용 등을 기준으로 0-100점을 매깁니다.',
+            chaos: '가능한 오래 살아남으세요. 시간이 지날수록 incident가 강해지고, 클러스터 health가 0이 되면 게임 오버입니다.',
+            campaign: '각 레벨의 목표를 완료해 다음 단계로 진행하세요. 더 빠르고 적은 리소스로 완료하면 별을 더 많이 받습니다.',
+            challenge: '제한 시간 안에 필요한 리소스를 배포하고 설정하세요.',
         };
 
         const controls = [
-            { key: 'Click palette', desc: 'Place a resource in your cluster' },
-            { key: 'Drag resource', desc: 'Move it anywhere in the 3D space' },
-            { key: 'Click resource', desc: 'Inspect it (status, YAML, describe)' },
-            { key: 'Right-click', desc: 'Scale, delete, logs, restart, rollback' },
-            { key: '/', desc: 'kubectl command bar (get, describe, scale, logs...)' },
-            { key: 'Space', desc: 'Pause / resume simulation' },
-            { key: 'M', desc: 'Toggle live metrics dashboard' },
-            { key: '1-9', desc: 'Quick-select resource from palette' },
-            { key: 'Scroll', desc: 'Zoom in/out' },
-            { key: 'Left-drag', desc: 'Rotate camera' },
-            { key: 'Right-drag', desc: 'Pan camera' },
-            { key: 'Esc', desc: 'Return to main menu' },
+            { key: '팔레트 클릭', desc: '클러스터에 리소스를 배치합니다' },
+            { key: '리소스 드래그', desc: '3D 공간에서 리소스를 이동합니다' },
+            { key: '리소스 클릭', desc: '상태, YAML, describe 정보를 확인합니다' },
+            { key: '우클릭', desc: '스케일, 삭제, 로그, 재시작, 롤백 작업을 실행합니다' },
+            { key: '/', desc: 'kubectl 명령창을 엽니다 (get, describe, scale, logs...)' },
+            { key: 'Space', desc: '시뮬레이션 일시정지 / 재개' },
+            { key: 'M', desc: '실시간 메트릭 대시보드 열기 / 닫기' },
+            { key: '1-9', desc: '팔레트 리소스 빠른 선택' },
+            { key: 'Scroll', desc: '확대 / 축소' },
+            { key: '왼쪽 드래그', desc: '카메라 회전' },
+            { key: '오른쪽 드래그', desc: '카메라 이동' },
+            { key: 'Esc', desc: '메인 메뉴로 돌아가기' },
         ];
 
         const modeRules = {
             sandbox: [
-                'Place any of the 17 resource types from the left palette',
-                'Use Auto-Align to organize into K8s architecture layout',
-                'Click YAML to export your cluster as a manifest file',
-                'Architecture Advisor scores: HA, security, networking, storage, scaling, RBAC, resource limits, probes, config management, cost',
+                '왼쪽 팔레트에서 원하는 리소스를 배치하세요',
+                '자동 정렬로 K8s 아키텍처 형태로 정리할 수 있습니다',
+                'YAML 버튼으로 클러스터를 manifest 파일로 내보낼 수 있습니다',
+                'Architecture Advisor는 HA, 보안, 네트워크, 스토리지, 스케일링, RBAC, 리소스 제한, probe, 설정 관리, 비용을 평가합니다',
             ],
             chaos: [
-                'You start with a running cluster — keep it alive',
-                'Incidents appear as red alerts in the top bar',
-                'Click the bell icon to see active incidents',
-                'Use kubectl describe and logs to diagnose issues',
-                'Resolve incidents by applying the correct fix',
-                'Speed increases over time — incidents come faster',
+                '실행 중인 클러스터로 시작합니다. 최대한 오래 살려두세요',
+                'Incident는 상단바의 빨간 알림으로 표시됩니다',
+                '종 아이콘을 눌러 진행 중인 incident를 확인하세요',
+                'kubectl describe와 logs로 문제를 진단하세요',
+                '올바른 조치를 적용해 incident를 해결하세요',
+                '시간이 지날수록 속도가 올라가고 incident가 더 빨리 발생합니다',
             ],
             campaign: [
-                'Ch 1 (L1-4): Pods, namespaces, nodes, multi-container pods',
-                'Ch 2 (L5-8): Deployments, rolling updates, StatefulSets, Jobs',
-                'Ch 3 (L9-12): Services, Ingress, NetworkPolicies, traffic',
-                'Ch 4 (L13-16): ConfigMaps, Secrets, PVCs, probes',
-                'Ch 5 (L17-20): HPA, ResourceQuotas, RBAC, production setup',
+                '1장 (L1-4): Pod, Namespace, Node, 스케줄링',
+                '2장 (L5-8): Deployment, Rolling Update, StatefulSet, Job',
+                '3장 (L9-12): Service, Ingress, NetworkPolicy, 트래픽',
+                '4장 (L13-16): ConfigMap, Secret, PVC, probe',
+                '5장 (L17-20): HPA, ResourceQuota, RBAC, 프로덕션 구성',
             ],
             challenge: [
-                '<b>Click resources</b> in the left palette to create them — a name prompt appears so you can match objective names (e.g. "frontend")',
-                '<b>Press /</b> to open the kubectl command bar — type commands like: <code>kubectl create deployment frontend</code>',
-                '<b>Name suggestions</b> appear as blue buttons when creating — click them to auto-fill the required name',
-                '<b>Click the lightbulb</b> (Show Hint) on the objectives panel for step-by-step guidance',
-                'Right-click any resource for actions: scale, delete, logs, restart',
+                '왼쪽 팔레트의 <b>리소스를 클릭</b>해 생성하세요. 목표 이름과 맞추도록 이름 입력창이 나타납니다 (예: "frontend")',
+                '<b>/ 키</b>를 눌러 kubectl 명령창을 열고 <code>kubectl create deployment frontend</code> 같은 명령을 입력하세요',
+                '생성 시 파란 버튼으로 <b>이름 추천</b>이 표시됩니다. 클릭하면 필요한 이름이 자동 입력됩니다',
+                '목표 패널의 <b>힌트 보기</b>를 눌러 단계별 안내를 확인하세요',
+                '리소스를 우클릭하면 스케일, 삭제, 로그, 재시작 작업을 할 수 있습니다',
             ],
         };
 
@@ -1785,7 +1785,7 @@
                     <div class="tutorial-desc">${modeGoals[mode] || ''}</div>
                 </div>
 
-                <div class="tutorial-section-label">How to Play</div>
+                <div class="tutorial-section-label">플레이 방법</div>
                 <div class="tutorial-tips">
                     ${rules.map(r => `
                         <div class="tutorial-tip">
@@ -1795,7 +1795,7 @@
                     `).join('')}
                 </div>
 
-                <div class="tutorial-section-label">Controls</div>
+                <div class="tutorial-section-label">조작법</div>
                 <div class="tutorial-tips">
                     ${controls.map(t => `
                         <div class="tutorial-tip">
@@ -1805,8 +1805,8 @@
                     `).join('')}
                 </div>
 
-                <button id="tutorial-start" class="tutorial-btn">Got it, let's go</button>
-                <div class="tutorial-hint">Press <span class="tutorial-hint-key">?</span> anytime to reopen this</div>
+                <button id="tutorial-start" class="tutorial-btn">좋아요, 시작하기</button>
+                <div class="tutorial-hint">언제든 <span class="tutorial-hint-key">?</span> 키로 다시 열 수 있습니다</div>
             </div>
         `;
         document.body.appendChild(overlay);
@@ -1840,7 +1840,7 @@
             const chapterInfo = CHAPTERS?.[chapter - 1] || { name: `Chapter ${chapter}` };
             const header = document.createElement('div');
             header.className = 'chapter-header';
-            header.textContent = `Chapter ${chapter}: ${chapterInfo.name || chapterInfo.title || ''}`;
+            header.textContent = `${chapter}장: ${chapterInfo.name || chapterInfo.title || ''}`;
             grid.appendChild(header);
           }
 
@@ -1853,7 +1853,7 @@
           card.className = `level-card ${isLocked ? 'locked' : ''} ${isCompleted ? 'completed' : ''}`;
           card.innerHTML = `
             <div class="level-number">${level.id}</div>
-            <div class="level-title">${level.title || level.name || `Level ${level.id}`}</div>
+              <div class="level-title">${level.title || level.name || `레벨 ${level.id}`}</div>
             <div class="level-stars">${isCompleted ? '&#9733;'.repeat(stars) + '&#9734;'.repeat(3 - stars) : '&#9734;&#9734;&#9734;'}</div>
           `;
 
@@ -1878,10 +1878,10 @@
           card.className = 'challenge-card';
           card.innerHTML = `
             <div class="challenge-info">
-              <div class="challenge-name">${ch.title || ch.name || `Challenge ${idx + 1}`}</div>
+              <div class="challenge-name">${ch.title || ch.name || `챌린지 ${idx + 1}`}</div>
               <div class="challenge-desc">${ch.description || ''}</div>
             </div>
-            <div class="challenge-time">${ch.timeLimit ? Math.floor(ch.timeLimit / 60) + ' min' : ''}</div>
+            <div class="challenge-time">${ch.timeLimit ? Math.floor(ch.timeLimit / 60) + '분' : ''}</div>
           `;
           card.addEventListener('click', () => {
             this.launchGame('challenge', ch.id || idx + 1);

--- a/js/i18n/ko.js
+++ b/js/i18n/ko.js
@@ -44,22 +44,102 @@ const CAMPAIGN_KO = {
       '흔한 원인은 잘못된 이미지 태그, 누락된 환경 변수, OOM, 잘못된 entrypoint입니다.'
     ]
   },
-  5: { title: 'Self-Healing과 Pod Eviction' },
-  6: { title: 'DaemonSet: Node마다 하나의 Pod' },
-  7: { title: 'Job과 CronJob: 배치 처리' },
-  8: { title: 'Rolling Update와 Rollback' },
-  9: { title: 'Service와 서비스 디스커버리' },
-  10: { title: 'Ingress: L7 HTTP 라우팅' },
-  11: { title: 'NetworkPolicy: Zero Trust' },
-  12: { title: 'DNS 디버깅' },
-  13: { title: 'ConfigMap 기본기' },
-  14: { title: 'Secret 운영' },
-  15: { title: '영구 스토리지' },
-  16: { title: 'StatefulSet 데이터베이스' },
-  17: { title: '프로덕션 준비성' },
-  18: { title: 'RBAC 방어선' },
-  19: { title: '멀티 노드 장애' },
-  20: { title: '풀스택 프로덕션' }
+  5: {
+    title: 'Self-Healing과 Pod Eviction',
+    description: 'Node의 메모리나 디스크가 부족하면 kubelet은 우선순위에 따라 Pod를 evict합니다. ReplicaSet은 원하는 replica 수와 실제 상태의 차이를 감지하고 건강한 Node에 replacement Pod를 만듭니다.',
+    objectives: ['서로 다른 마이크로서비스 Deployment 3개 실행', '각 Deployment를 replica 2개 이상으로 구성', '다운타임 없이 Pod eviction 2건 대응'],
+    hints: ['web, api, worker 같은 Deployment를 만들고 각각 2개 이상으로 scale하세요.', 'Eviction이 발생하면 ReplicaSet이 replacement Pod를 자동 생성합니다.', 'resource request/limit을 설정하면 BestEffort eviction 위험을 줄일 수 있습니다.']
+  },
+  6: {
+    title: 'DaemonSet: Node마다 하나의 Pod',
+    description: 'DaemonSet은 모든 Node 또는 선택된 Node마다 Pod 한 개가 실행되도록 보장합니다. 로그 수집기, 모니터링 에이전트, CNI 플러그인처럼 Node 단위로 필요한 구성요소에 사용됩니다.',
+    objectives: ['DaemonSet 만들기', 'Node를 4개로 확장하기', '모든 Node에서 DaemonSet Pod 실행 확인'],
+    hints: ['팔레트에서 DaemonSet을 생성하세요.', 'Node를 추가하면 DaemonSet controller가 자동으로 Pod를 배치합니다.', 'DaemonSet의 desiredNumberScheduled와 currentNumberScheduled를 확인하세요.']
+  },
+  7: {
+    title: 'Job과 CronJob: 배치 처리',
+    description: 'Job은 Pod를 완료 상태까지 실행하고 성공 횟수를 추적합니다. CronJob은 cron 스케줄에 따라 Job을 주기적으로 생성합니다.',
+    objectives: ['Job 2개 만들기', '두 Job이 Complete 상태가 되게 하기', 'CronJob 1개 만들기'],
+    hints: ['Job Pod는 Pending -> Running -> Succeeded 순서로 진행됩니다.', 'CronJob schedule은 "*/5 * * * *" 같은 cron 문법을 사용합니다.', 'activeDeadlineSeconds나 backoffLimit 초과 시 Job은 실패할 수 있습니다.']
+  },
+  8: {
+    title: 'Rolling Update와 Rollback',
+    description: 'Deployment를 업데이트하면 새 ReplicaSet이 만들어지고 기존 ReplicaSet은 점진적으로 줄어듭니다. 새 버전이 실패하면 rollout undo로 이전 ReplicaSet으로 되돌릴 수 있습니다.',
+    objectives: ['Rolling update 트리거', '이미지 pull 실패 시 rollback', 'rollout 중 90% 가용성 유지'],
+    hints: ['api-server를 우클릭해 Rolling Update를 실행하세요.', 'ImagePullBackOff는 대개 잘못된 이미지 태그 때문입니다.', '"kubectl rollout undo deployment api-server"로 되돌릴 수 있습니다.']
+  },
+  9: {
+    title: 'Service와 서비스 디스커버리',
+    description: 'Service는 Pod 집합에 안정적인 네트워크 엔드포인트를 제공합니다. label selector로 대상 Pod를 찾고, Pod가 교체되어도 Service 주소는 유지됩니다.',
+    objectives: ['Service 만들기', 'Service를 Deployment에 연결', '트래픽 흐름 확인'],
+    hints: ['Service selector가 Pod label과 일치해야 합니다.', 'Service를 만들고 대상 Deployment를 선택하세요.', '연결선으로 Service -> Pod 라우팅을 확인할 수 있습니다.']
+  },
+  10: {
+    title: 'Ingress: L7 HTTP 라우팅',
+    description: 'Ingress는 HTTP 경로와 host 기반으로 외부 트래픽을 Service에 라우팅합니다. TLS termination도 함께 구성할 수 있습니다.',
+    objectives: ['Ingress 만들기', '경로 기반 라우팅 구성', 'TLS Secret 연결'],
+    hints: ['Ingress는 Service 앞단의 L7 라우터 역할을 합니다.', '/app, /api 같은 path를 각 Service로 라우팅하세요.', 'TLS를 위해 Secret 리소스를 생성하세요.']
+  },
+  11: {
+    title: 'NetworkPolicy: Zero Trust',
+    description: 'NetworkPolicy는 Pod 간 허용 트래픽을 명시합니다. 기본 허용 모델에서 필요한 통신만 열어주는 zero-trust 네트워크로 전환할 수 있습니다.',
+    objectives: ['NetworkPolicy 만들기', 'database namespace 격리', 'backend -> database만 허용'],
+    hints: ['NetworkPolicy가 선택한 Pod는 명시적으로 허용된 트래픽만 받습니다.', 'database namespace에 default deny 정책을 적용하세요.', '필요한 경로만 별도 정책으로 허용하세요.']
+  },
+  12: {
+    title: 'DNS 디버깅',
+    description: 'Kubernetes의 Service discovery는 CoreDNS에 크게 의존합니다. DNS가 깨지면 Service 이름으로 서로를 찾지 못합니다.',
+    objectives: ['DNS 실패 조사', 'CoreDNS 관련 incident 해결', 'Service discovery 복구'],
+    hints: ['kube-system namespace의 CoreDNS 상태를 확인하세요.', 'NetworkPolicy가 DNS egress를 막고 있지 않은지 확인하세요.', 'Service 이름 해석 실패는 app 문제가 아니라 DNS 문제일 수 있습니다.']
+  },
+  13: {
+    title: 'ConfigMap 기본기',
+    description: 'ConfigMap은 비밀이 아닌 설정값을 Pod에 주입하는 리소스입니다. 환경 변수나 파일 형태로 앱 설정을 분리할 수 있습니다.',
+    objectives: ['ConfigMap 만들기', 'Deployment에 설정 연결', '설정 변경 적용'],
+    hints: ['ConfigMap에는 일반 설정값을 넣고 Secret에는 민감 정보를 넣으세요.', 'Pod가 ConfigMap을 환경 변수나 볼륨으로 사용할 수 있습니다.', '설정 변경 후 rollout restart가 필요할 수 있습니다.']
+  },
+  14: {
+    title: 'Secret 운영',
+    description: 'Secret은 비밀번호, 토큰, 인증서 같은 민감 데이터를 저장합니다. ConfigMap과 달리 민감 정보 전용으로 사용해야 합니다.',
+    objectives: ['Secret 만들기', 'Deployment에 Secret 연결', '민감 정보 노출 방지'],
+    hints: ['Secret 값은 base64로 인코딩되지만 암호화와는 다릅니다.', '환경 변수나 volume으로 Pod에 주입할 수 있습니다.', '민감 정보는 ConfigMap에 넣지 마세요.']
+  },
+  15: {
+    title: '영구 스토리지',
+    description: 'PV와 PVC는 Pod 생명주기와 분리된 저장소를 제공합니다. Pod가 재시작되어도 데이터가 유지되게 만듭니다.',
+    objectives: ['PersistentVolume 만들기', 'PersistentVolumeClaim 만들기', 'Pod에 PVC 연결'],
+    hints: ['PVC는 사용자의 스토리지 요청입니다.', 'PV는 실제 제공되는 스토리지입니다.', 'Pod가 삭제되어도 PV의 데이터는 유지될 수 있습니다.']
+  },
+  16: {
+    title: 'StatefulSet 데이터베이스',
+    description: 'StatefulSet은 안정적인 Pod 이름과 저장소를 제공해 데이터베이스처럼 상태가 중요한 워크로드에 적합합니다.',
+    objectives: ['StatefulSet 만들기', 'PVC 연결', 'replica별 안정적인 identity 확인'],
+    hints: ['StatefulSet Pod는 app-0, app-1처럼 안정적인 이름을 가집니다.', 'Headless Service가 StatefulSet DNS에 자주 사용됩니다.', '각 replica는 독립 PVC를 사용할 수 있습니다.']
+  },
+  17: {
+    title: '프로덕션 준비성',
+    description: '프로덕션 워크로드에는 probe, resource limit, autoscaling, 가용성 전략이 필요합니다. 단순 실행을 넘어 운영 가능한 상태로 만들어야 합니다.',
+    objectives: ['liveness/readiness probe 구성', 'resource request/limit 설정', 'HPA 구성'],
+    hints: ['readiness probe는 트래픽을 받을 준비가 되었는지 판단합니다.', 'liveness probe는 죽은 컨테이너를 재시작하게 합니다.', 'request/limit은 스케줄링과 안정성에 중요합니다.']
+  },
+  18: {
+    title: 'RBAC 방어선',
+    description: 'RBAC는 누가 어떤 Kubernetes 리소스에 어떤 작업을 할 수 있는지 제한합니다. 최소 권한 원칙을 적용하세요.',
+    objectives: ['ServiceAccount 만들기', 'Role과 RoleBinding 구성', 'wildcard 권한 제거'],
+    hints: ['Role은 namespace 범위 권한입니다.', 'RoleBinding으로 ServiceAccount에 권한을 부여합니다.', '*, cluster-admin 같은 과도한 권한은 피하세요.']
+  },
+  19: {
+    title: '멀티 노드 장애',
+    description: '두 Node가 동시에 다운되는 critical incident입니다. 서비스 가용성을 유지하면서 Node와 Pod를 복구해야 합니다.',
+    objectives: ['실패한 Node 2개 복구', '서비스 가용성 80% 유지', 'evict된 Pod 5개 재스케줄', 'PodDisruptionBudget 만들기'],
+    hints: ['Node 장애 incident를 조사하고 해결하세요.', 'Node maintenance에는 cordon과 drain이 사용됩니다.', 'PDB는 중단 상황에서 최소 가용성을 보호합니다.']
+  },
+  20: {
+    title: '풀스택 프로덕션',
+    description: '최종 챌린지입니다. namespace, workload, service, ingress, network policy, secret, autoscaling까지 포함한 프로덕션급 구성을 처음부터 만듭니다.',
+    objectives: ['frontend/backend/data namespace 만들기', '애플리케이션 4개 배포', '모든 Deployment를 Service로 노출', 'Ingress 라우팅 구성', 'NetworkPolicy로 트래픽 분리', 'Secret과 HPA 구성', '모든 Deployment에 probe 추가', 'Architecture 점수 75 이상 달성'],
+    hints: ['namespace 3개를 먼저 만들고 각 영역에 Deployment를 배치하세요.', '각 Deployment에 Service를 만들고 Ingress로 외부 라우팅을 구성하세요.', 'NetworkPolicy, Secret, HPA, probe를 추가해 점수를 올리세요.']
+  }
 };
 
 const CHAPTERS_KO = [
@@ -81,6 +161,87 @@ const CHALLENGE_TITLES_KO = {
   'RBAC Fortress': 'RBAC 방어선',
   'DNS Resolution Failure': 'DNS 해석 실패',
   'Full Production Readiness': '전체 프로덕션 준비성'
+};
+
+const CHALLENGES_KO = {
+  1: {
+    description: 'frontend(nginx), backend(node), database(postgres)로 구성된 3계층 애플리케이션을 배포하고 각각 Service를 붙이세요.',
+    objectives: ['frontend 배포', 'backend 배포', 'database 배포', 'Service 3개 만들기', 'frontend가 backend에 연결되게 하기'],
+    hints: ['팔레트에서 Deploy를 클릭하고 이름을 frontend로 지정하세요.', 'backend와 database도 같은 방식으로 만드세요.', '각 Deployment마다 Service를 하나씩 만드세요.', '/ 키를 눌러 kubectl create deployment frontend를 입력해도 됩니다.', 'Service는 같은 namespace의 Deployment에 자동 연결됩니다.']
+  },
+  2: {
+    description: '중요한 프로덕션 Pod가 crash loop에 빠졌습니다. 사용자 영향이 커지기 전에 조사하고 복구하세요.',
+    objectives: ['크래시 원인 조사', 'CrashLoopBackOff 해결', '클러스터 health 90%로 복구'],
+    hints: ['/ 키를 눌러 kubectl describe pod payment-service를 실행하세요.', 'Events 섹션에서 크래시 원인을 찾으세요.', 'kubectl logs로 컨테이너 출력을 확인하세요.', 'kubectl rollout restart deployment payment-service로 재시작할 수 있습니다.']
+  },
+  3: {
+    description: 'TLS termination이 있는 Ingress를 구성하고 /app, /api 경로를 각각 올바른 Service로 라우팅하세요.',
+    objectives: ['Ingress 만들기', '/app과 /api 라우팅', 'TLS 활성화', 'TLS Secret 만들기'],
+    hints: ['Ingress를 만들고 /app, /api route를 구성하세요.', 'TLS termination을 위해 kubernetes.io/tls 타입 Secret을 만드세요.', 'Ingress는 기존 app-svc와 api-svc Service에 연결됩니다.']
+  },
+  4: {
+    description: 'zero-trust 네트워킹을 구현하세요. namespace를 격리하고 필요한 트래픽만 허용해야 합니다.',
+    objectives: ['NetworkPolicy 3개 만들기', 'database namespace 격리', 'backend -> database 허용', 'frontend -> database 차단'],
+    hints: ['database namespace에 기본 deny 정책을 만드세요.', 'app=api label을 가진 Pod에서 오는 ingress만 허용하세요.', 'frontend에서 database로 가는 트래픽은 차단되어야 합니다.']
+  },
+  5: {
+    description: '트래픽이 급증했습니다. 고객이 이탈하기 전에 애플리케이션을 빠르게 확장하세요.',
+    objectives: ['web을 replica 10개로 확장', 'api를 replica 8개로 확장', 'HPA 2개 만들기', 'Node 5개 확보'],
+    hints: ['kubectl scale deployment web --replicas=10을 실행하세요.', 'kubectl scale deployment api --replicas=8도 실행하세요.', 'HPA를 만들어 자동 확장을 켜세요.', 'Pod가 Pending이면 Node를 더 추가하세요.']
+  },
+  6: {
+    description: 'Node 장애로 여러 Pod가 함께 사라졌습니다. 클러스터를 복구하고 workload가 다시 스케줄되게 하세요.',
+    objectives: ['실패한 Node 복구', 'evict된 Pod 3개 재스케줄', 'health 85%로 복구', 'PodDisruptionBudget 만들기'],
+    hints: ['kubectl uncordon node-2로 Node를 복구하세요.', '실패한 Node의 Pod는 scheduler가 다시 배치합니다.', '향후 중단을 줄이려면 PDB를 만드세요.']
+  },
+  7: {
+    description: '영구 스토리지와 headless Service를 갖춘 replica 3개의 StatefulSet 데이터베이스를 배포하세요.',
+    objectives: ['StatefulSet 만들기', 'replica 3개로 확장', 'PVC 3개 만들기', 'headless Service 만들기', 'PV 3개 만들기'],
+    hints: ['StatefulSet은 안정적인 Pod identity를 유지합니다.', 'kubectl scale statefulset <name> --replicas=3으로 확장하세요.', '각 replica에 PVC가 필요합니다.', 'headless Service는 clusterIP: None을 사용합니다.', 'PVC를 뒷받침할 PV도 만들어야 합니다.']
+  },
+  8: {
+    description: '전용 ServiceAccount, 최소 권한 Role, RoleBinding으로 올바른 RBAC를 구현하세요.',
+    objectives: ['ServiceAccount 2개 만들기', 'Role 2개 만들기', 'RoleBinding 2개 만들기', 'wildcard 권한 제거', 'UnauthorizedAccess 해결'],
+    hints: ['워크로드마다 필요한 identity를 따로 만드세요.', 'Role은 구체적인 권한만 가져야 합니다.', 'RoleBinding으로 Role을 ServiceAccount에 연결하세요.', '기존 overprivileged-sa의 과도한 권한을 최소 권한으로 바꾸세요.']
+  },
+  9: {
+    description: 'CoreDNS가 다운되어 Service discovery가 실패하고 있습니다. DNS 인프라를 진단하고 복구하세요.',
+    objectives: ['DNS 실패 조사', 'DNS resolution 복구', 'NetworkPolicy에서 DNS egress 허용'],
+    hints: ['strict-deny NetworkPolicy가 DNS를 막고 있습니다.', 'kube-dns 53번 포트로 egress를 허용하는 NetworkPolicy를 만드세요.', 'kubectl describe로 기존 NetworkPolicy rule을 확인하세요.']
+  },
+  10: {
+    description: '10분 안에 namespace, app, service, ingress, network policy, secret, HPA, probe를 갖춘 프로덕션급 클러스터를 만드세요.',
+    objectives: ['namespace 3개 만들기', '애플리케이션 3개 배포', 'Service로 노출', 'Ingress 구성', '네트워크 분리', 'credential을 Secret에 저장', 'autoscaling 구성', 'health probe 추가', 'Architecture 점수 70 이상'],
+    hints: ['frontend, backend, database 같은 namespace 3개를 만드세요.', 'namespace마다 애플리케이션을 하나씩 배포하세요.', 'Service와 Ingress로 외부 접근 경로를 만드세요.', 'NetworkPolicy로 namespace 간 트래픽을 분리하세요.', 'Secret과 HPA를 구성하세요.', 'Deployment에 liveness/readiness probe를 추가하세요.']
+  }
+};
+
+const TEXT_REPLACEMENTS = {
+  'Settings': '설정',
+  'Achievements': '업적',
+  'Stats': '통계',
+  'Total Pods': '전체 Pod',
+  'Incidents Resolved': '해결한 Incident',
+  'Commands Run': '실행한 명령',
+  'Time Played': '플레이 시간',
+  'Campaign Stars': '캠페인 별',
+  'Best Chaos Time': '최고 카오스 기록',
+  'XP Level': 'XP 레벨',
+  'Keep playing to unlock': '계속 플레이하면 해금됩니다',
+  'No resources to export': '내보낼 리소스가 없습니다',
+  'Auto-Align': '자동 정렬',
+  'Reset View': '화면 초기화',
+  'Help': '도움말',
+  'Workloads': 'Workload',
+  'Network': '네트워크',
+  'Config': '설정',
+  'Storage': '스토리지',
+  'Cluster': '클러스터',
+  'Security': '보안',
+  'Share': '공유',
+  'Clear': '초기화',
+  'Draw Line': '연결선',
+  'Auto-Layout': '자동 배치'
 };
 
 const STATIC_TEXT_KO = [
@@ -149,6 +310,15 @@ export function applyKoreanLocale({ CAMPAIGN_LEVELS, CHAPTERS, ACHIEVEMENTS, CHA
       if (CHALLENGE_TITLES_KO[challenge.title]) {
         challenge.title = CHALLENGE_TITLES_KO[challenge.title];
       }
+      const ko = CHALLENGES_KO[challenge.id];
+      if (!ko) return;
+      if (ko.description) challenge.description = ko.description;
+      if (ko.objectives && Array.isArray(challenge.objectives)) {
+        challenge.objectives.forEach((objective, index) => {
+          if (ko.objectives[index]) objective.label = ko.objectives[index];
+        });
+      }
+      if (ko.hints) challenge.hints = ko.hints;
     });
   }
 
@@ -160,8 +330,46 @@ export function applyKoreanLocale({ CAMPAIGN_LEVELS, CHAPTERS, ACHIEVEMENTS, CHA
     });
   }
 
+  installTextReplacementObserver();
+
   window.K8S_GAMES_KO = {
     unofficial: true,
     notice: '비공식 한국어 배포판입니다. 원본 K8s Games는 Rohit Ghumare가 Apache-2.0으로 배포했습니다.'
   };
+}
+
+function installTextReplacementObserver() {
+  const replace = (root = document.body) => {
+    if (!root) return;
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    const pending = [];
+    while (walker.nextNode()) pending.push(walker.currentNode);
+    for (const node of pending) {
+      const text = node.nodeValue;
+      const trimmed = text.trim();
+      if (!trimmed || !TEXT_REPLACEMENTS[trimmed]) continue;
+      node.nodeValue = text.replace(trimmed, TEXT_REPLACEMENTS[trimmed]);
+    }
+    root.querySelectorAll?.('[title]').forEach((el) => {
+      const title = el.getAttribute('title');
+      if (TEXT_REPLACEMENTS[title]) el.setAttribute('title', TEXT_REPLACEMENTS[title]);
+    });
+  };
+
+  replace();
+
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (node.nodeType === Node.ELEMENT_NODE) replace(node);
+        else if (node.nodeType === Node.TEXT_NODE) {
+          const trimmed = node.nodeValue.trim();
+          if (TEXT_REPLACEMENTS[trimmed]) {
+            node.nodeValue = node.nodeValue.replace(trimmed, TEXT_REPLACEMENTS[trimmed]);
+          }
+        }
+      }
+    }
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
 }

--- a/js/i18n/ko.js
+++ b/js/i18n/ko.js
@@ -1,0 +1,167 @@
+/*
+ * Korean localization additions for the unofficial Korean distribution.
+ * Modified from K8s Games, Copyright 2026 Rohit Ghumare, Apache-2.0.
+ */
+
+const CAMPAIGN_KO = {
+  1: {
+    title: '첫 번째 Pod',
+    description: 'Pod는 Kubernetes에서 배포할 수 있는 가장 작은 단위입니다. 하나 이상의 컨테이너가 네트워크 네임스페이스와 스토리지 볼륨을 공유합니다. 이 레벨에서는 Pod를 만들고 Namespace로 리소스를 분리합니다.',
+    objectives: ['Pod 배포하기 (K8s의 기본 실행 단위)', '리소스 격리를 위한 Namespace 만들기'],
+    hints: [
+      '"kubectl run my-pod --image=nginx"를 입력해 nginx 컨테이너를 실행하는 Pod를 만드세요.',
+      '"kubectl create namespace staging"을 입력해 Namespace를 만드세요. Namespace는 물리 클러스터 안의 가상 클러스터처럼 동작합니다.',
+      'Pod를 클릭해 단계(Pending -> ContainerCreating -> Running), IP, condition을 확인하세요.'
+    ]
+  },
+  2: {
+    title: 'Deployment와 ReplicaSet',
+    description: '프로덕션에서는 보통 단독 Pod를 직접 만들지 않습니다. Deployment는 원하는 상태를 선언하고 ReplicaSet이 Pod 수를 맞추도록 합니다. 이것이 Kubernetes의 self-healing을 가능하게 하는 조정 루프입니다.',
+    objectives: ['Deployment 만들기 (원하는 Pod 상태 선언)', 'ReplicaSet이 수렴하도록 replica를 3개로 확장하기'],
+    hints: [
+      '"kubectl create deployment web"을 입력하고 Deployment -> ReplicaSet -> Pod 소유 관계를 관찰하세요.',
+      '"kubectl scale deployment web --replicas=3"으로 replica를 늘리세요.',
+      'Pod 하나를 삭제해 보세요. ReplicaSet이 차이를 감지하고 다시 만듭니다.'
+    ]
+  },
+  3: {
+    title: '스케줄링과 멀티 노드 클러스터',
+    description: 'kube-scheduler는 CPU/메모리, affinity, taint/toleration 등을 기준으로 Pod를 Node에 배치합니다. 여러 Node에 분산하면 한 Node가 실패해도 다른 Node의 Pod가 계속 트래픽을 처리할 수 있습니다.',
+    objectives: ['Node를 3개로 확장하기', 'Pod 6개 실행해 scheduler 분산 확인하기', 'Pod가 최소 2개 Node에 배치되게 하기'],
+    hints: [
+      '"kubectl create node"로 Node를 추가하세요.',
+      'replica가 있는 Deployment를 만들면 scheduler가 가용 리소스에 따라 Pod를 배치합니다.',
+      'Node를 클릭해 allocatable CPU/메모리와 배치된 Pod 수를 확인하세요.'
+    ]
+  },
+  4: {
+    title: 'CrashLoopBackOff',
+    description: 'CrashLoopBackOff는 컨테이너가 시작 후 반복적으로 종료되고 Kubernetes가 재시작 간격을 점점 늘리는 상태입니다. describe와 logs --previous로 원인을 추적합니다.',
+    objectives: ['CrashLoopBackOff 진단 및 해결', '클러스터 health 95% 이상 유지'],
+    hints: [
+      '붉게 표시되는 Pod를 클릭해 restartCount와 Waiting 상태를 확인하세요.',
+      '실제 K8s에서는 "kubectl describe pod <name>"과 "kubectl logs <name> --previous"를 사용합니다.',
+      '흔한 원인은 잘못된 이미지 태그, 누락된 환경 변수, OOM, 잘못된 entrypoint입니다.'
+    ]
+  },
+  5: { title: 'Self-Healing과 Pod Eviction' },
+  6: { title: 'DaemonSet: Node마다 하나의 Pod' },
+  7: { title: 'Job과 CronJob: 배치 처리' },
+  8: { title: 'Rolling Update와 Rollback' },
+  9: { title: 'Service와 서비스 디스커버리' },
+  10: { title: 'Ingress: L7 HTTP 라우팅' },
+  11: { title: 'NetworkPolicy: Zero Trust' },
+  12: { title: 'DNS 디버깅' },
+  13: { title: 'ConfigMap 기본기' },
+  14: { title: 'Secret 운영' },
+  15: { title: '영구 스토리지' },
+  16: { title: 'StatefulSet 데이터베이스' },
+  17: { title: '프로덕션 준비성' },
+  18: { title: 'RBAC 방어선' },
+  19: { title: '멀티 노드 장애' },
+  20: { title: '풀스택 프로덕션' }
+};
+
+const CHAPTERS_KO = [
+  { name: '기초', description: 'Pod, Deployment, 스케줄링, 첫 incident 대응' },
+  { name: 'Workload', description: 'Self-healing, DaemonSet, 배치 Job, Rolling Update 전략' },
+  { name: '네트워킹', description: 'Service, Ingress L7 라우팅, NetworkPolicy, DNS 디버깅' },
+  { name: '상태와 설정', description: '상태 저장과 설정 관리' },
+  { name: '프로덕션', description: '프로덕션급 클러스터 구축' }
+];
+
+const CHALLENGE_TITLES_KO = {
+  'Three-Tier Web App': '3계층 웹 앱',
+  'Fix CrashLoopBackOff': 'CrashLoopBackOff 해결',
+  'Ingress with TLS': 'TLS가 적용된 Ingress',
+  'Network Segmentation': '네트워크 분리',
+  'Black Friday Scaling': '블랙프라이데이 스케일링',
+  'Node Failure Recovery': 'Node 장애 복구',
+  'StatefulSet with PVC': 'PVC를 사용하는 StatefulSet',
+  'RBAC Fortress': 'RBAC 방어선',
+  'DNS Resolution Failure': 'DNS 해석 실패',
+  'Full Production Readiness': '전체 프로덕션 준비성'
+};
+
+const STATIC_TEXT_KO = [
+  ['.menu-subtitle', 'Kubernetes 클러스터 시뮬레이션'],
+  ['.github-text', 'GitHub에서 Star'],
+  ['[data-mode="campaign"] .menu-btn-title', '캠페인'],
+  ['[data-mode="campaign"] .menu-btn-desc', 'Pod부터 프로덕션까지 20개 레벨로 단계별 학습'],
+  ['[data-mode="chaos"] .menu-btn-title', '카오스 모드'],
+  ['[data-mode="chaos"] .menu-btn-desc', '점점 커지는 장애를 버티는 SRE 훈련'],
+  ['[data-mode="sandbox"] .menu-btn-title', '샌드박스'],
+  ['[data-mode="sandbox"] .menu-btn-desc', '자유롭게 클러스터를 설계하고 점수를 확인'],
+  ['[data-mode="challenge"] .menu-btn-title', '챌린지'],
+  ['[data-mode="challenge"] .menu-btn-desc', '10개의 시간 제한 시나리오에서 장애를 해결'],
+  ['.menu-draw-link > span:first-of-type', 'K8s Draw'],
+  ['.menu-draw-desc', '3D로 K8s 아키텍처를 설계하고 YAML로 내보내기'],
+  ['#btn-settings', '설정'],
+  ['#btn-achievements', '업적'],
+  ['#btn-stats', '통계'],
+  ['#btn-show-hint', '힌트 보기'],
+  ['#btn-auto-align', '자동 정렬'],
+  ['#btn-reset-camera', '화면 초기화'],
+  ['#btn-help', '도움말']
+];
+
+export function applyKoreanLocale({ CAMPAIGN_LEVELS, CHAPTERS, ACHIEVEMENTS, CHALLENGES } = {}) {
+  document.documentElement.lang = 'ko';
+  document.title = 'K8s Games 한국어 배포판 - Kubernetes 클러스터 시뮬레이션';
+
+  const description = document.querySelector('meta[name="description"]');
+  if (description) {
+    description.content = '게임으로 Kubernetes를 배워보세요. Pod를 배포하고, 장애를 처리하고, kubectl 명령을 익힙니다.';
+  }
+
+  for (const [selector, text] of STATIC_TEXT_KO) {
+    const el = document.querySelector(selector);
+    if (el) el.textContent = text;
+  }
+
+  const hints = document.querySelector('.menu-keyboard-hints');
+  if (hints) {
+    hints.innerHTML = '<span class="keyboard-hint">/</span> kubectl &middot; <span class="keyboard-hint">Space</span> 일시정지 &middot; <span class="keyboard-hint">M</span> 메트릭 &middot; <span class="keyboard-hint">Esc</span> 메뉴';
+  }
+
+  if (Array.isArray(CHAPTERS)) {
+    CHAPTERS.forEach((chapter, index) => Object.assign(chapter, CHAPTERS_KO[index] || {}));
+  }
+
+  if (Array.isArray(CAMPAIGN_LEVELS)) {
+    CAMPAIGN_LEVELS.forEach((level) => {
+      const ko = CAMPAIGN_KO[level.id];
+      if (!ko) return;
+      if (ko.title) level.title = ko.title;
+      if (ko.description) level.description = ko.description;
+      if (ko.objectives && Array.isArray(level.objectives)) {
+        level.objectives.forEach((objective, index) => {
+          if (ko.objectives[index]) objective.label = ko.objectives[index];
+        });
+      }
+      if (ko.hints) level.hints = ko.hints;
+      level.chapterName = CHAPTERS?.[level.chapter - 1]?.name || level.chapterName;
+    });
+  }
+
+  if (Array.isArray(CHALLENGES)) {
+    CHALLENGES.forEach((challenge) => {
+      if (CHALLENGE_TITLES_KO[challenge.title]) {
+        challenge.title = CHALLENGE_TITLES_KO[challenge.title];
+      }
+    });
+  }
+
+  if (Array.isArray(ACHIEVEMENTS)) {
+    ACHIEVEMENTS.forEach((achievement) => {
+      if (achievement.name === 'First Steps') achievement.name = '첫걸음';
+      if (achievement.name === 'Pod Master') achievement.name = 'Pod 마스터';
+      if (achievement.name === 'Incident Commander') achievement.name = 'Incident Commander';
+    });
+  }
+
+  window.K8S_GAMES_KO = {
+    unofficial: true,
+    notice: '비공식 한국어 배포판입니다. 원본 K8s Games는 Rohit Ghumare가 Apache-2.0으로 배포했습니다.'
+  };
+}

--- a/js/ui/CommandBar.js
+++ b/js/ui/CommandBar.js
@@ -75,9 +75,9 @@ export class CommandBar {
     return `
       <div class="backdrop-blur-xl bg-white/5 border-t border-white/10 shadow-2xl">
         <div class="flex items-center justify-between px-4 py-2 border-b border-white/5">
-          <span class="text-white/40 text-xs font-mono">Terminal</span>
+          <span class="text-white/40 text-xs font-mono">터미널</span>
           <div class="flex items-center gap-2">
-            <span class="text-white/20 text-xs">Press / to toggle</span>
+            <span class="text-white/20 text-xs">/ 키로 열고 닫기</span>
             <button id="cmd-close" class="text-white/30 hover:text-white/60 transition-colors">
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
@@ -89,7 +89,7 @@ export class CommandBar {
         <div class="relative px-4 py-3 border-t border-white/5">
           <div class="flex items-center gap-2">
             <span class="text-green-400 text-sm font-mono shrink-0">$ kubectl</span>
-            <input id="cmd-input" type="text" class="flex-1 bg-transparent text-white/90 text-sm font-mono outline-none placeholder:text-white/20" placeholder="enter command..." autocomplete="off" spellcheck="false" />
+            <input id="cmd-input" type="text" class="flex-1 bg-transparent text-white/90 text-sm font-mono outline-none placeholder:text-white/20" placeholder="명령어 입력..." autocomplete="off" spellcheck="false" />
           </div>
           <div id="cmd-suggestions" class="absolute bottom-full left-0 right-0 hidden"></div>
         </div>

--- a/js/ui/ContextMenu.js
+++ b/js/ui/ContextMenu.js
@@ -1,15 +1,15 @@
 const ACTION_MAP = {
   Pod: [
     { group: 'inspect', actions: [
-      { label: 'View Logs', event: 'pod:logs', shortcut: 'L' },
+      { label: '로그 보기', event: 'pod:logs', shortcut: 'L' },
       { label: 'Describe', event: 'resource:describe', shortcut: 'D' },
     ]},
     { group: 'manage', actions: [
-      { label: 'Exec Into', event: 'pod:exec', shortcut: 'E' },
-      { label: 'Port Forward', event: 'pod:port-forward', shortcut: 'F' },
+      { label: '컨테이너 접속', event: 'pod:exec', shortcut: 'E' },
+      { label: '포트 포워딩', event: 'pod:port-forward', shortcut: 'F' },
     ]},
     { group: 'danger', actions: [
-      { label: 'Delete', event: 'resource:delete', shortcut: 'Del', danger: true },
+      { label: '삭제', event: 'resource:delete', shortcut: 'Del', danger: true },
     ]},
   ],
   Deployment: [
@@ -17,32 +17,32 @@ const ACTION_MAP = {
       { label: 'Describe', event: 'resource:describe', shortcut: 'D' },
     ]},
     { group: 'manage', actions: [
-      { label: 'Scale', event: 'deployment:scale', shortcut: 'S' },
-      { label: 'Restart', event: 'deployment:restart', shortcut: 'R' },
-      { label: 'Rollback', event: 'deployment:rollback', shortcut: 'B' },
+      { label: '스케일', event: 'deployment:scale', shortcut: 'S' },
+      { label: '재시작', event: 'deployment:restart', shortcut: 'R' },
+      { label: '롤백', event: 'deployment:rollback', shortcut: 'B' },
     ]},
     { group: 'danger', actions: [
-      { label: 'Delete', event: 'resource:delete', shortcut: 'Del', danger: true },
+      { label: '삭제', event: 'resource:delete', shortcut: 'Del', danger: true },
     ]},
   ],
   Service: [
     { group: 'inspect', actions: [
       { label: 'Describe', event: 'resource:describe', shortcut: 'D' },
-      { label: 'View Endpoints', event: 'service:endpoints', shortcut: 'E' },
+      { label: 'Endpoint 보기', event: 'service:endpoints', shortcut: 'E' },
     ]},
     { group: 'danger', actions: [
-      { label: 'Delete', event: 'resource:delete', shortcut: 'Del', danger: true },
+      { label: '삭제', event: 'resource:delete', shortcut: 'Del', danger: true },
     ]},
   ],
   Node: [
     { group: 'inspect', actions: [
       { label: 'Describe', event: 'resource:describe', shortcut: 'D' },
-      { label: 'Top', event: 'node:top', shortcut: 'T' },
+      { label: '사용량 보기', event: 'node:top', shortcut: 'T' },
     ]},
     { group: 'manage', actions: [
-      { label: 'Cordon', event: 'node:cordon', shortcut: 'C' },
-      { label: 'Uncordon', event: 'node:uncordon', shortcut: 'U' },
-      { label: 'Drain', event: 'node:drain', shortcut: 'N' },
+      { label: '스케줄 금지', event: 'node:cordon', shortcut: 'C' },
+      { label: '스케줄 허용', event: 'node:uncordon', shortcut: 'U' },
+      { label: 'Drain 실행', event: 'node:drain', shortcut: 'N' },
     ]},
   ],
 };
@@ -52,7 +52,7 @@ const DEFAULT_ACTIONS = [
     { label: 'Describe', event: 'resource:describe', shortcut: 'D' },
   ]},
   { group: 'danger', actions: [
-    { label: 'Delete', event: 'resource:delete', shortcut: 'Del', danger: true },
+    { label: '삭제', event: 'resource:delete', shortcut: 'Del', danger: true },
   ]},
 ];
 

--- a/js/ui/HUD.js
+++ b/js/ui/HUD.js
@@ -45,9 +45,9 @@ export class HUD {
     return `
       <div class="flex items-center justify-between px-4 py-2 backdrop-blur-xl bg-white/5 border-b border-white/10 pointer-events-auto">
         <div class="flex items-center gap-4">
-          <button id="hud-menu" class="px-2 py-1 text-xs text-white/60 hover:text-white/90 hover:bg-white/10 rounded-lg transition-all flex items-center gap-1.5" title="Back to Menu (Esc)">
+          <button id="hud-menu" class="px-2 py-1 text-xs text-white/60 hover:text-white/90 hover:bg-white/10 rounded-lg transition-all flex items-center gap-1.5" title="메뉴로 돌아가기 (Esc)">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/></svg>
-            <span>Menu</span>
+            <span>메뉴</span>
           </button>
           <div class="hud-divider h-5 w-px bg-white/10"></div>
           <div class="flex items-center gap-2">
@@ -57,7 +57,7 @@ export class HUD {
           <div class="hud-divider h-5 w-px bg-white/10"></div>
           <div class="flex items-center gap-3 text-xs text-white/60">
             <div class="flex items-center gap-1">
-              <span class="text-white/40">Nodes</span>
+              <span class="text-white/40">Node</span>
               <span id="hud-nodes" class="text-white/90 font-mono">0</span>
             </div>
             <div class="flex items-center gap-1">
@@ -134,13 +134,13 @@ export class HUD {
             <span id="hud-alert-badge" class="absolute -top-1 -right-1 hidden min-w-[16px] h-4 px-1 text-[10px] font-bold text-white bg-red-500 rounded-full flex items-center justify-center">0</span>
           </button>
 
-          <button id="hud-settings" class="px-2 py-0.5 text-xs text-white/60 hover:text-white/90 transition-colors" title="Settings">
+          <button id="hud-settings" class="px-2 py-0.5 text-xs text-white/60 hover:text-white/90 transition-colors" title="설정">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><circle cx="12" cy="12" r="3"/></svg>
           </button>
 
           <div class="hud-divider h-5 w-px bg-white/10"></div>
 
-          <a href="https://github.com/rohitg00/k8sgames" target="_blank" rel="noopener" class="hud-github flex items-center gap-1.5 px-2 py-0.5 text-xs text-white/50 hover:text-white/90 transition-all rounded-md hover:bg-white/5" title="Star on GitHub">
+          <a href="https://github.com/rohitg00/k8sgames" target="_blank" rel="noopener" class="hud-github flex items-center gap-1.5 px-2 py-0.5 text-xs text-white/50 hover:text-white/90 transition-all rounded-md hover:bg-white/5" title="원작자 GitHub 저장소">
             <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
               <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
             </svg>

--- a/js/ui/IncidentPanel.js
+++ b/js/ui/IncidentPanel.js
@@ -1,5 +1,36 @@
 import { INCIDENT_DEFS } from '../data/IncidentDefs.js';
 
+const STEP_HINT_KO = {
+  'Check previous container logs for crash reason': '이전 컨테이너 로그에서 크래시 원인을 확인',
+  'Look at Events section for restart count and reasons': 'Events 섹션에서 재시작 횟수와 원인 확인',
+  'Check cluster events for this Pod': '이 Pod와 관련된 클러스터 이벤트 확인',
+  'Check the image name and pull errors in Events': 'Events에서 이미지 이름과 pull 오류 확인',
+  'Verify the image reference': '이미지 참조가 올바른지 확인',
+  'Look for OOMKilled in Last State': 'Last State에서 OOMKilled 여부 확인',
+  'Check current memory usage': '현재 메모리 사용량 확인',
+  'Review resource limits': '리소스 limit 설정 검토',
+  'Check eviction reason in Status': 'Status에서 eviction 원인 확인',
+  'Check node conditions for resource pressure': 'Node condition에서 리소스 압박 상태 확인',
+  'Review node resource usage': 'Node 리소스 사용량 확인',
+  'Check readiness probe configuration and failure messages': 'readiness probe 설정과 실패 메시지 확인',
+  'Look for application startup issues': '애플리케이션 시작 문제 확인',
+  'Check if Pod is in Service endpoints': 'Pod가 Service endpoint에 포함되어 있는지 확인',
+  'Check for finalizers preventing deletion': '삭제를 막는 finalizer 확인',
+  'List finalizers': 'finalizer 목록 확인',
+  'Check conditions: MemoryPressure, DiskPressure, PIDPressure': 'MemoryPressure, DiskPressure, PIDPressure condition 확인',
+  'List all Pods on this node': '이 Node에 있는 모든 Pod 확인',
+  'Check node events': 'Node 이벤트 확인',
+  'Check DiskPressure condition': 'DiskPressure condition 확인',
+  'Find large or old Pods': '용량이 크거나 오래된 Pod 찾기',
+  'Check node memory usage percentage': 'Node 메모리 사용률 확인',
+  'Find highest memory consumers': '메모리를 많이 쓰는 Pod 찾기',
+  'Check PIDPressure condition': 'PIDPressure condition 확인',
+  'List Pods on the affected node': '영향받은 Node의 Pod 목록 확인',
+  'Check if endpoints list is empty': 'endpoint 목록이 비어 있는지 확인',
+  'Verify selector matches Pod labels': 'selector가 Pod label과 일치하는지 확인',
+  'Check Pod labels match Service selector': 'Pod label이 Service selector와 맞는지 확인',
+};
+
 const SEVERITY_CONFIG = {
   critical: { icon: '\u26a0', color: 'red', bg: 'bg-red-500/10', border: 'border-red-500/20', text: 'text-red-400' },
   warning: { icon: '\u26a0', color: 'yellow', bg: 'bg-yellow-500/10', border: 'border-yellow-500/20', text: 'text-yellow-400' },
@@ -10,7 +41,7 @@ const INVESTIGATION_STEPS = {};
 for (const def of INCIDENT_DEFS) {
   if (def.investigationSteps && def.investigationSteps.length > 0) {
     INVESTIGATION_STEPS[def.name] = def.investigationSteps.map(step => ({
-      label: step.hint,
+      label: STEP_HINT_KO[step.hint] || step.hint,
       cmd: step.command.replace('<pod>', '{name}').replace('<node>', '{name}').replace('<service>', '{name}').replace('<policy>', '{name}').replace('<ingress>', '{name}').replace('<namespace>', '{name}'),
     }));
   }
@@ -49,7 +80,7 @@ export class IncidentPanel {
             <svg class="w-4 h-4 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"/>
             </svg>
-            <span class="text-white/90 text-sm font-semibold">Incidents</span>
+            <span class="text-white/90 text-sm font-semibold">Incident</span>
             <span id="incident-count" class="text-xs text-white/30 font-mono">0</span>
           </div>
           <button id="incident-close" class="p-1 text-white/30 hover:text-white/60 transition-colors">
@@ -60,13 +91,13 @@ export class IncidentPanel {
         </div>
 
         <div class="flex border-b border-white/5">
-          <button data-filter="active" class="flex-1 px-3 py-2 text-xs text-sky-400 border-b-2 border-sky-400 font-medium transition-colors">Active</button>
-          <button data-filter="resolved" class="flex-1 px-3 py-2 text-xs text-white/40 border-b-2 border-transparent hover:text-white/60 transition-colors">Resolved</button>
-          <button data-filter="all" class="flex-1 px-3 py-2 text-xs text-white/40 border-b-2 border-transparent hover:text-white/60 transition-colors">All</button>
+          <button data-filter="active" class="flex-1 px-3 py-2 text-xs text-sky-400 border-b-2 border-sky-400 font-medium transition-colors">진행 중</button>
+          <button data-filter="resolved" class="flex-1 px-3 py-2 text-xs text-white/40 border-b-2 border-transparent hover:text-white/60 transition-colors">해결됨</button>
+          <button data-filter="all" class="flex-1 px-3 py-2 text-xs text-white/40 border-b-2 border-transparent hover:text-white/60 transition-colors">전체</button>
         </div>
 
         <div id="incident-list" class="flex-1 overflow-y-auto scrollbar-thin p-3 space-y-2">
-          <div class="text-white/20 text-sm text-center mt-8">No incidents reported</div>
+          <div class="text-white/20 text-sm text-center mt-8">보고된 incident가 없습니다</div>
         </div>
       </div>
     `;
@@ -106,7 +137,7 @@ export class IncidentPanel {
       severity: data.severity || 'warning',
       resource: data.resource || data.target || 'unknown',
       resourceUid: data.uid,
-      message: data.message || data.description || 'An incident occurred',
+      message: data.message || data.description || 'Incident가 발생했습니다',
       timestamp: Date.now(),
       status: 'active',
       resolvedAt: null,
@@ -165,9 +196,9 @@ export class IncidentPanel {
   }
 
   _emptyMessage() {
-    if (this.filter === 'active') return 'No active incidents';
-    if (this.filter === 'resolved') return 'No resolved incidents';
-    return 'No incidents recorded';
+    if (this.filter === 'active') return '진행 중인 incident가 없습니다';
+    if (this.filter === 'resolved') return '해결된 incident가 없습니다';
+    return '기록된 incident가 없습니다';
   }
 
   _getFilteredIncidents() {
@@ -221,8 +252,8 @@ export class IncidentPanel {
           ${incident.expanded && steps.length > 0 ? `
             <div class="mt-2 pt-2 border-t border-white/5">
               <div class="flex items-center justify-between mb-1.5">
-                <div class="text-white/30 text-[10px] uppercase tracking-wider">Investigation</div>
-                ${incident.status === 'active' ? `<div class="text-[10px] font-mono ${completedCount >= this._requiredSteps ? 'text-green-400' : 'text-white/30'}">${completedCount}/${steps.length} investigated</div>` : ''}
+                <div class="text-white/30 text-[10px] uppercase tracking-wider">조사</div>
+                ${incident.status === 'active' ? `<div class="text-[10px] font-mono ${completedCount >= this._requiredSteps ? 'text-green-400' : 'text-white/30'}">${completedCount}/${steps.length} 확인됨</div>` : ''}
               </div>
               <div class="space-y-1">
                 ${steps.map((step, idx) => {
@@ -231,7 +262,7 @@ export class IncidentPanel {
                   return `
                     <div class="flex items-center gap-2 group">
                       <span class="text-[11px] w-4 text-center ${done ? 'text-green-400' : 'text-white/15'}">${done ? '\u2713' : '\u25CB'}</span>
-                      <button class="flex-1 text-left px-2 py-1 text-[11px] font-mono ${done ? 'text-green-400/60 bg-green-400/5' : 'text-white/40 hover:text-white/60 bg-white/5 hover:bg-white/10'} rounded transition-colors run-cmd" data-cmd="${this._escapeHTML(cmd)}" title="Click to copy to command bar">
+                      <button class="flex-1 text-left px-2 py-1 text-[11px] font-mono ${done ? 'text-green-400/60 bg-green-400/5' : 'text-white/40 hover:text-white/60 bg-white/5 hover:bg-white/10'} rounded transition-colors run-cmd" data-cmd="${this._escapeHTML(cmd)}" title="클릭하면 명령창에 복사됩니다">
                         ${this._escapeHTML(step.label)}
                       </button>
                     </div>
@@ -244,22 +275,22 @@ export class IncidentPanel {
           <div class="flex items-center gap-2 mt-2">
             ${steps.length > 0 ? `
               <button class="toggle-expand text-[10px] text-white/30 hover:text-white/50 transition-colors">
-                ${incident.expanded ? 'Hide steps' : 'Investigate'}
+                ${incident.expanded ? '단계 숨기기' : '조사하기'}
               </button>
             ` : ''}
             ${incident.status === 'active' ? (
               canResolve ? `
                 <button class="resolve-btn ml-auto px-2 py-0.5 text-[10px] text-green-400 hover:bg-green-400/10 rounded transition-colors">
-                  Resolve
+                  해결
                 </button>
               ` : `
-                <span class="ml-auto flex items-center gap-1 text-[10px] text-white/20" title="Run investigation commands first">
+                <span class="ml-auto flex items-center gap-1 text-[10px] text-white/20" title="조사 명령을 먼저 실행하세요">
                   <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/></svg>
-                  Investigate first
+                  먼저 조사 필요
                 </span>
               `
             ) : `
-              <span class="ml-auto text-[10px] text-green-400/50">Resolved</span>
+              <span class="ml-auto text-[10px] text-green-400/50">해결됨</span>
             `}
           </div>
         </div>

--- a/js/ui/InspectorPanel.js
+++ b/js/ui/InspectorPanel.js
@@ -25,12 +25,12 @@ export class InspectorPanel {
           <div class="flex items-center gap-2 min-w-0">
             <div id="inspector-icon" class="w-8 h-8 rounded-lg bg-sky-500/20 flex items-center justify-center text-sky-400 text-sm font-bold shrink-0">P</div>
             <div class="min-w-0">
-              <div id="inspector-name" class="text-white/90 text-sm font-semibold truncate">No Selection</div>
-              <div id="inspector-subtitle" class="text-white/40 text-xs truncate">Select a resource</div>
+              <div id="inspector-name" class="text-white/90 text-sm font-semibold truncate">선택 없음</div>
+              <div id="inspector-subtitle" class="text-white/40 text-xs truncate">리소스를 선택하세요</div>
             </div>
           </div>
           <div class="flex items-center gap-1 shrink-0">
-            <button id="inspector-edit" class="hidden px-2 py-1 text-xs text-sky-400 hover:bg-sky-400/10 rounded transition-colors">Edit</button>
+            <button id="inspector-edit" class="hidden px-2 py-1 text-xs text-sky-400 hover:bg-sky-400/10 rounded transition-colors">편집</button>
             <button id="inspector-close" class="p-1 text-white/30 hover:text-white/60 transition-colors">
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
@@ -40,14 +40,14 @@ export class InspectorPanel {
         </div>
 
         <div id="inspector-tabs" class="flex border-b border-white/5 px-2">
-          <button data-tab="overview" class="px-3 py-2 text-xs text-sky-400 border-b-2 border-sky-400 font-medium transition-colors">Overview</button>
+          <button data-tab="overview" class="px-3 py-2 text-xs text-sky-400 border-b-2 border-sky-400 font-medium transition-colors">개요</button>
           <button data-tab="yaml" class="px-3 py-2 text-xs text-white/40 border-b-2 border-transparent hover:text-white/60 transition-colors">YAML</button>
-          <button data-tab="events" class="px-3 py-2 text-xs text-white/40 border-b-2 border-transparent hover:text-white/60 transition-colors">Events</button>
+          <button data-tab="events" class="px-3 py-2 text-xs text-white/40 border-b-2 border-transparent hover:text-white/60 transition-colors">이벤트</button>
           <button data-tab="describe" class="px-3 py-2 text-xs text-white/40 border-b-2 border-transparent hover:text-white/60 transition-colors">Describe</button>
         </div>
 
         <div id="inspector-body" class="flex-1 overflow-y-auto scrollbar-thin p-4">
-          <div class="text-white/30 text-sm text-center mt-8">Select a resource to inspect</div>
+          <div class="text-white/30 text-sm text-center mt-8">확인할 리소스를 선택하세요</div>
         </div>
       </div>
     `;
@@ -146,7 +146,7 @@ export class InspectorPanel {
   _renderTab() {
     const body = document.getElementById('inspector-body');
     if (!this.resource) {
-      body.innerHTML = '<div class="text-white/30 text-sm text-center mt-8">Select a resource to inspect</div>';
+      body.innerHTML = '<div class="text-white/30 text-sm text-center mt-8">확인할 리소스를 선택하세요</div>';
       return;
     }
 
@@ -166,7 +166,7 @@ export class InspectorPanel {
     let sections = `
       <div class="space-y-4">
         <div>
-          <div class="text-white/30 text-xs uppercase tracking-wider mb-2">Status</div>
+          <div class="text-white/30 text-xs uppercase tracking-wider mb-2">상태</div>
           <div class="flex items-center gap-2">
             <div class="w-2 h-2 rounded-full ${statusColor}"></div>
             <span class="text-white/80 text-sm">${r.status?.phase || r.status?.state || 'Active'}</span>
@@ -174,30 +174,30 @@ export class InspectorPanel {
         </div>
 
         <div>
-          <div class="text-white/30 text-xs uppercase tracking-wider mb-2">Metadata</div>
+          <div class="text-white/30 text-xs uppercase tracking-wider mb-2">메타데이터</div>
           <div class="space-y-1.5">
-            ${this._metaRow('Name', r.metadata?.name)}
+            ${this._metaRow('이름', r.metadata?.name)}
             ${this._metaRow('Namespace', r.metadata?.namespace || 'default')}
             ${this._metaRow('UID', r.metadata?.uid)}
-            ${this._metaRow('Created', this._formatTimestamp(r.metadata?.creationTimestamp))}
+            ${this._metaRow('생성', this._formatTimestamp(r.metadata?.creationTimestamp))}
           </div>
         </div>
 
         <div>
-          <div class="text-white/30 text-xs uppercase tracking-wider mb-2">Labels</div>
+          <div class="text-white/30 text-xs uppercase tracking-wider mb-2">레이블</div>
           <div class="flex flex-wrap gap-1">
             ${Object.entries(r.metadata?.labels || {}).map(([k, v]) =>
               `<span class="px-2 py-0.5 text-xs bg-white/5 border border-white/10 rounded text-white/60">${this._escapeHTML(k)}=${this._escapeHTML(v)}</span>`
-            ).join('') || '<span class="text-white/20 text-xs">No labels</span>'}
+            ).join('') || '<span class="text-white/20 text-xs">레이블 없음</span>'}
           </div>
         </div>
 
         <div>
-          <div class="text-white/30 text-xs uppercase tracking-wider mb-2">Annotations</div>
+          <div class="text-white/30 text-xs uppercase tracking-wider mb-2">어노테이션</div>
           <div class="space-y-1">
             ${Object.entries(r.metadata?.annotations || {}).map(([k, v]) =>
               `<div class="text-xs"><span class="text-white/40">${this._escapeHTML(k)}</span><span class="text-white/20">: </span><span class="text-white/60">${this._escapeHTML(v)}</span></div>`
-            ).join('') || '<span class="text-white/20 text-xs">No annotations</span>'}
+            ).join('') || '<span class="text-white/20 text-xs">어노테이션 없음</span>'}
           </div>
         </div>
     `;
@@ -220,24 +220,24 @@ export class InspectorPanel {
     const containers = r.spec?.containers || [{ name: 'main', image: 'unknown:latest' }];
     return `
       <div>
-        <div class="text-white/30 text-xs uppercase tracking-wider mb-2">Containers</div>
+        <div class="text-white/30 text-xs uppercase tracking-wider mb-2">컨테이너</div>
         <div class="space-y-2">
           ${containers.map(c => `
             <div class="p-2 bg-white/5 rounded-lg border border-white/5">
               <div class="text-white/80 text-xs font-medium">${this._escapeHTML(c.name)}</div>
               <div class="text-white/40 text-xs mt-0.5">${this._escapeHTML(c.image || 'unknown')}</div>
-              ${c.ports ? `<div class="text-white/30 text-xs mt-0.5">Ports: ${c.ports.map(p => p.containerPort).join(', ')}</div>` : ''}
+              ${c.ports ? `<div class="text-white/30 text-xs mt-0.5">포트: ${c.ports.map(p => p.containerPort).join(', ')}</div>` : ''}
             </div>
           `).join('')}
         </div>
       </div>
       <div>
-        <div class="text-white/30 text-xs uppercase tracking-wider mb-2">Pod Info</div>
+        <div class="text-white/30 text-xs uppercase tracking-wider mb-2">Pod 정보</div>
         <div class="space-y-1.5">
-          ${this._metaRow('Node', r.spec?.nodeName || 'unscheduled')}
+          ${this._metaRow('Node', r.spec?.nodeName || '미스케줄')}
           ${this._metaRow('IP', r.status?.podIP || 'pending')}
-          ${this._metaRow('Restarts', r.status?.restartCount || 0)}
-          ${this._metaRow('QoS Class', r.status?.qosClass || 'BestEffort')}
+          ${this._metaRow('재시작', r.status?.restartCount || 0)}
+          ${this._metaRow('QoS 클래스', r.status?.qosClass || 'BestEffort')}
         </div>
       </div>
     `;
@@ -246,12 +246,12 @@ export class InspectorPanel {
   _renderDeploymentDetails(r) {
     return `
       <div>
-        <div class="text-white/30 text-xs uppercase tracking-wider mb-2">Deployment Info</div>
+        <div class="text-white/30 text-xs uppercase tracking-wider mb-2">Deployment 정보</div>
         <div class="space-y-1.5">
-          ${this._metaRow('Replicas', `${r.status?.readyReplicas || 0}/${r.spec?.replicas || 0} ready`)}
-          ${this._metaRow('Strategy', r.spec?.strategy?.type || 'RollingUpdate')}
-          ${this._metaRow('Available', r.status?.availableReplicas || 0)}
-          ${this._metaRow('Updated', r.status?.updatedReplicas || 0)}
+          ${this._metaRow('Replica', `${r.status?.readyReplicas || 0}/${r.spec?.replicas || 0} 준비됨`)}
+          ${this._metaRow('전략', r.spec?.strategy?.type || 'RollingUpdate')}
+          ${this._metaRow('가용', r.status?.availableReplicas || 0)}
+          ${this._metaRow('업데이트됨', r.status?.updatedReplicas || 0)}
         </div>
       </div>
     `;
@@ -260,11 +260,11 @@ export class InspectorPanel {
   _renderServiceDetails(r) {
     return `
       <div>
-        <div class="text-white/30 text-xs uppercase tracking-wider mb-2">Service Info</div>
+        <div class="text-white/30 text-xs uppercase tracking-wider mb-2">Service 정보</div>
         <div class="space-y-1.5">
-          ${this._metaRow('Type', r.spec?.type || 'ClusterIP')}
+          ${this._metaRow('타입', r.spec?.type || 'ClusterIP')}
           ${this._metaRow('Cluster IP', r.spec?.clusterIP || '10.96.0.1')}
-          ${this._metaRow('Ports', (r.spec?.ports || []).map(p => `${p.port}/${p.protocol || 'TCP'}`).join(', ') || '<none>')}
+          ${this._metaRow('포트', (r.spec?.ports || []).map(p => `${p.port}/${p.protocol || 'TCP'}`).join(', ') || '<없음>')}
           ${this._metaRow('Selector', Object.entries(r.spec?.selector || {}).map(([k, v]) => `${k}=${v}`).join(', ') || '<none>')}
         </div>
       </div>
@@ -274,16 +274,16 @@ export class InspectorPanel {
   _renderNodeDetails(r) {
     return `
       <div>
-        <div class="text-white/30 text-xs uppercase tracking-wider mb-2">Node Info</div>
+        <div class="text-white/30 text-xs uppercase tracking-wider mb-2">Node 정보</div>
         <div class="space-y-1.5">
           ${this._metaRow('OS', r.status?.nodeInfo?.operatingSystem || 'linux')}
-          ${this._metaRow('Architecture', r.status?.nodeInfo?.architecture || 'amd64')}
+          ${this._metaRow('아키텍처', r.status?.nodeInfo?.architecture || 'amd64')}
           ${this._metaRow('Kubelet', r.status?.nodeInfo?.kubeletVersion || 'v1.29.0')}
-          ${this._metaRow('Container Runtime', r.status?.nodeInfo?.containerRuntimeVersion || 'containerd://1.7.0')}
+          ${this._metaRow('컨테이너 런타임', r.status?.nodeInfo?.containerRuntimeVersion || 'containerd://1.7.0')}
         </div>
       </div>
       <div>
-        <div class="text-white/30 text-xs uppercase tracking-wider mb-2">Capacity</div>
+        <div class="text-white/30 text-xs uppercase tracking-wider mb-2">용량</div>
         <div class="space-y-1.5">
           ${this._metaRow('CPU', r.status?.capacity?.cpu || '4 cores')}
           ${this._metaRow('Memory', r.status?.capacity?.memory || '16Gi')}
@@ -328,7 +328,7 @@ export class InspectorPanel {
   _renderEvents() {
     const events = this.resource._events || this._generateSampleEvents();
     if (events.length === 0) {
-      return '<div class="text-white/30 text-sm text-center mt-4">No events recorded</div>';
+      return '<div class="text-white/30 text-sm text-center mt-4">기록된 이벤트가 없습니다</div>';
     }
 
     return `
@@ -354,20 +354,20 @@ export class InspectorPanel {
 
     if (kind === 'Pod') {
       return [
-        { type: 'Normal', reason: 'Scheduled', message: `Successfully assigned default/${name} to node-1`, timestamp: this._timeAgo(now, 5) },
-        { type: 'Normal', reason: 'Pulling', message: `Pulling image "${this.resource.spec?.containers?.[0]?.image || 'nginx:latest'}"`, timestamp: this._timeAgo(now, 4) },
-        { type: 'Normal', reason: 'Pulled', message: 'Container image pulled successfully', timestamp: this._timeAgo(now, 3) },
-        { type: 'Normal', reason: 'Created', message: 'Created container main', timestamp: this._timeAgo(now, 2) },
-        { type: 'Normal', reason: 'Started', message: 'Started container main', timestamp: this._timeAgo(now, 1) },
+        { type: 'Normal', reason: 'Scheduled', message: `default/${name} Pod가 node-1에 성공적으로 배치되었습니다`, timestamp: this._timeAgo(now, 5) },
+        { type: 'Normal', reason: 'Pulling', message: `"${this.resource.spec?.containers?.[0]?.image || 'nginx:latest'}" 이미지를 가져오는 중`, timestamp: this._timeAgo(now, 4) },
+        { type: 'Normal', reason: 'Pulled', message: '컨테이너 이미지를 성공적으로 가져왔습니다', timestamp: this._timeAgo(now, 3) },
+        { type: 'Normal', reason: 'Created', message: 'main 컨테이너를 생성했습니다', timestamp: this._timeAgo(now, 2) },
+        { type: 'Normal', reason: 'Started', message: 'main 컨테이너를 시작했습니다', timestamp: this._timeAgo(now, 1) },
       ];
     }
     if (kind === 'Deployment') {
       return [
-        { type: 'Normal', reason: 'ScalingReplicaSet', message: `Scaled up replica set ${name}-7d6f4c8b to ${this.resource.spec?.replicas || 1}`, timestamp: this._timeAgo(now, 3) },
+        { type: 'Normal', reason: 'ScalingReplicaSet', message: `${name}-7d6f4c8b ReplicaSet을 ${this.resource.spec?.replicas || 1}개로 확장했습니다`, timestamp: this._timeAgo(now, 3) },
       ];
     }
     return [
-      { type: 'Normal', reason: 'Created', message: `${kind} ${name} created successfully`, timestamp: this._timeAgo(now, 2) },
+      { type: 'Normal', reason: 'Created', message: `${kind} ${name} 리소스가 생성되었습니다`, timestamp: this._timeAgo(now, 2) },
     ];
   }
 
@@ -457,12 +457,12 @@ export class InspectorPanel {
   }
 
   _formatTimestamp(ts) {
-    if (!ts) return 'Unknown';
+    if (!ts) return '알 수 없음';
     return new Date(ts).toLocaleString();
   }
 
   _timeAgo(now, minutesAgo) {
-    return `${minutesAgo}m ago`;
+    return `${minutesAgo}분 전`;
   }
 
   _escapeHTML(str) {

--- a/js/ui/MetricsDashboard.js
+++ b/js/ui/MetricsDashboard.js
@@ -43,11 +43,11 @@ export class MetricsDashboard {
       <div class="backdrop-blur-xl bg-white/5 border-t border-white/10 shadow-2xl" style="height: 240px;">
         <div class="flex items-center justify-between px-4 py-2 border-b border-white/5">
           <div class="flex items-center gap-3">
-            <span class="text-white/40 text-xs font-mono">Metrics</span>
-            <span id="metrics-scope" class="text-white/20 text-xs">Cluster-wide</span>
+            <span class="text-white/40 text-xs font-mono">메트릭</span>
+            <span id="metrics-scope" class="text-white/20 text-xs">클러스터 전체</span>
           </div>
           <div class="flex items-center gap-2">
-            <span class="text-white/20 text-xs">Press M to toggle</span>
+            <span class="text-white/20 text-xs">M 키로 열고 닫기</span>
             <button id="metrics-close" class="p-1 text-white/30 hover:text-white/60 transition-colors">
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
@@ -62,17 +62,17 @@ export class MetricsDashboard {
             <canvas id="metrics-canvas-cpu" class="w-full h-full rounded-lg bg-white/5 border border-white/5"></canvas>
           </div>
           <div class="relative">
-            <div class="absolute top-0 left-0 text-[10px] text-white/30 z-10 px-1">Memory %</div>
+            <div class="absolute top-0 left-0 text-[10px] text-white/30 z-10 px-1">메모리 %</div>
             <div class="absolute top-0 right-0 text-[10px] font-mono z-10 px-1" id="metrics-mem-val" style="color: ${CHART_COLORS.memory.line}">0%</div>
             <canvas id="metrics-canvas-memory" class="w-full h-full rounded-lg bg-white/5 border border-white/5"></canvas>
           </div>
           <div class="relative">
-            <div class="absolute top-0 left-0 text-[10px] text-white/30 z-10 px-1">Network KB/s</div>
+            <div class="absolute top-0 left-0 text-[10px] text-white/30 z-10 px-1">네트워크 KB/s</div>
             <div class="absolute top-0 right-0 text-[10px] font-mono z-10 px-1" id="metrics-net-val" style="color: ${CHART_COLORS.network.line}">0</div>
             <canvas id="metrics-canvas-network" class="w-full h-full rounded-lg bg-white/5 border border-white/5"></canvas>
           </div>
           <div class="relative">
-            <div class="absolute top-0 left-0 text-[10px] text-white/30 z-10 px-1">Pod Count</div>
+            <div class="absolute top-0 left-0 text-[10px] text-white/30 z-10 px-1">Pod 수</div>
             <div class="absolute top-0 right-0 text-[10px] font-mono z-10 px-1" id="metrics-pods-val" style="color: ${CHART_COLORS.pods.line}">0</div>
             <canvas id="metrics-canvas-pods" class="w-full h-full rounded-lg bg-white/5 border border-white/5"></canvas>
           </div>
@@ -116,7 +116,7 @@ export class MetricsDashboard {
 
   _onResourceDeselect() {
     this.selectedResource = null;
-    document.getElementById('metrics-scope').textContent = 'Cluster-wide';
+    document.getElementById('metrics-scope').textContent = '클러스터 전체';
   }
 
   _onKeydown(e) {
@@ -180,8 +180,8 @@ export class MetricsDashboard {
 
   _onResourceSelect(data) {
     this.selectedResource = window.game?.cluster?.getResource(data.uid) || null;
-    const name = this.selectedResource?.metadata?.name || 'Unknown';
-    document.getElementById('metrics-scope').textContent = this.selectedResource ? `Resource: ${name}` : 'Cluster-wide';
+    const name = this.selectedResource?.metadata?.name || '알 수 없음';
+    document.getElementById('metrics-scope').textContent = this.selectedResource ? `리소스: ${name}` : '클러스터 전체';
   }
 
   _onResize() {

--- a/js/ui/SettingsPanel.js
+++ b/js/ui/SettingsPanel.js
@@ -1,8 +1,8 @@
 const DIFFICULTY_PRESETS = {
-  easy: { label: 'Easy', description: 'Slower incidents, more resources', failureRate: 0.5, resourceMultiplier: 1.5 },
-  normal: { label: 'Normal', description: 'Balanced experience', failureRate: 1.0, resourceMultiplier: 1.0 },
-  hard: { label: 'Hard', description: 'Faster incidents, fewer resources', failureRate: 2.0, resourceMultiplier: 0.75 },
-  nightmare: { label: 'Nightmare', description: 'Relentless chaos', failureRate: 3.0, resourceMultiplier: 0.5 },
+  easy: { label: '쉬움', description: '장애는 느리게, 리소스는 넉넉하게', failureRate: 0.5, resourceMultiplier: 1.5 },
+  normal: { label: '보통', description: '균형 잡힌 플레이 경험', failureRate: 1.0, resourceMultiplier: 1.0 },
+  hard: { label: '어려움', description: '장애는 빠르게, 리소스는 적게', failureRate: 2.0, resourceMultiplier: 0.75 },
+  nightmare: { label: '악몽', description: '쉴 틈 없는 카오스', failureRate: 3.0, resourceMultiplier: 0.5 },
 };
 
 const STORAGE_KEY = 'k8sgames_settings';
@@ -54,7 +54,7 @@ export class SettingsPanel {
       <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" data-action="backdrop"></div>
       <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[480px] max-h-[80vh] overflow-y-auto rounded-xl border border-white/10 bg-gray-900/95 backdrop-blur-xl shadow-2xl">
         <div class="flex items-center justify-between px-6 py-4 border-b border-white/5">
-          <h2 class="text-white/90 text-base font-semibold">Settings</h2>
+          <h2 class="text-white/90 text-base font-semibold">설정</h2>
           <button data-action="close" class="p-1 text-white/30 hover:text-white/60 transition-colors">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
@@ -64,7 +64,7 @@ export class SettingsPanel {
 
         <div class="px-6 py-4 space-y-6">
           <div>
-            <div class="text-white/60 text-xs font-semibold uppercase tracking-wider mb-3">Difficulty</div>
+            <div class="text-white/60 text-xs font-semibold uppercase tracking-wider mb-3">난이도</div>
             <div class="grid grid-cols-2 gap-2">
               ${Object.entries(DIFFICULTY_PRESETS).map(([key, preset]) => `
                 <button class="settings-difficulty px-3 py-2 rounded-lg border text-left transition-all ${key === diff ? 'border-sky-500/50 bg-sky-500/10' : 'border-white/5 bg-white/5 hover:bg-white/10'}" data-difficulty="${key}">
@@ -76,24 +76,24 @@ export class SettingsPanel {
           </div>
 
           <div>
-            <div class="text-white/60 text-xs font-semibold uppercase tracking-wider mb-3">Display</div>
+            <div class="text-white/60 text-xs font-semibold uppercase tracking-wider mb-3">표시</div>
             <div class="space-y-2">
-              ${this._buildToggle('showMinimap', 'Show Minimap', 'Display cluster overview in bottom-right corner')}
-              ${this._buildToggle('showConnectionLines', 'Connection Lines', 'Show ownership and networking lines between resources')}
-              ${this._buildToggle('particleEffects', 'Particle Effects', 'Animated traffic particles along connections')}
-              ${this._buildToggle('autoExpandIncidents', 'Auto-Expand Incidents', 'Automatically show investigation steps for new incidents')}
+              ${this._buildToggle('showMinimap', '미니맵 표시', '오른쪽 아래에 클러스터 전체 개요를 표시합니다')}
+              ${this._buildToggle('showConnectionLines', '연결선 표시', '리소스 간 소유 관계와 네트워크 연결을 표시합니다')}
+              ${this._buildToggle('particleEffects', '파티클 효과', '연결선을 따라 이동하는 트래픽 애니메이션을 표시합니다')}
+              ${this._buildToggle('autoExpandIncidents', 'Incident 자동 펼침', '새 incident의 조사 단계를 자동으로 보여줍니다')}
             </div>
           </div>
 
           <div>
-            <div class="text-white/60 text-xs font-semibold uppercase tracking-wider mb-3">Gameplay</div>
+            <div class="text-white/60 text-xs font-semibold uppercase tracking-wider mb-3">게임플레이</div>
             <div class="space-y-2">
-              ${this._buildToggle('showHints', 'Show Hints', 'Display hints for campaign level objectives')}
+              ${this._buildToggle('showHints', '힌트 표시', '캠페인 레벨 목표에 대한 힌트를 표시합니다')}
             </div>
           </div>
 
           <div>
-            <div class="text-white/60 text-xs font-semibold uppercase tracking-wider mb-3">Camera Speed</div>
+            <div class="text-white/60 text-xs font-semibold uppercase tracking-wider mb-3">카메라 속도</div>
             <div class="flex items-center gap-3">
               <input type="range" data-action="camera-speed" min="0.5" max="2.0" step="0.1" value="${this.settings.cameraSpeed}" class="flex-1 h-1 bg-white/10 rounded-full appearance-none cursor-pointer accent-sky-400">
               <span data-label="camera-speed-val" class="text-white/60 text-xs font-mono w-8">${this.settings.cameraSpeed}x</span>
@@ -101,16 +101,16 @@ export class SettingsPanel {
           </div>
 
           <div class="pt-2 border-t border-white/5">
-            <div class="text-white/60 text-xs font-semibold uppercase tracking-wider mb-3">Data</div>
+            <div class="text-white/60 text-xs font-semibold uppercase tracking-wider mb-3">데이터</div>
             <div class="flex gap-2">
-              <button data-action="reset-progress" class="px-3 py-1.5 text-xs text-red-400 border border-red-500/20 rounded-lg hover:bg-red-500/10 transition-colors">Reset All Progress</button>
-              <button data-action="export" class="px-3 py-1.5 text-xs text-white/50 border border-white/10 rounded-lg hover:bg-white/5 transition-colors">Export Save</button>
+              <button data-action="reset-progress" class="px-3 py-1.5 text-xs text-red-400 border border-red-500/20 rounded-lg hover:bg-red-500/10 transition-colors">진행도 초기화</button>
+              <button data-action="export" class="px-3 py-1.5 text-xs text-white/50 border border-white/10 rounded-lg hover:bg-white/5 transition-colors">저장 데이터 내보내기</button>
             </div>
           </div>
         </div>
 
         <div class="px-6 py-3 border-t border-white/5 flex justify-end">
-          <button data-action="done" class="px-4 py-1.5 text-sm text-sky-400 bg-sky-400/10 rounded-lg hover:bg-sky-400/20 transition-colors font-medium">Done</button>
+          <button data-action="done" class="px-4 py-1.5 text-sm text-sky-400 bg-sky-400/10 rounded-lg hover:bg-sky-400/20 transition-colors font-medium">완료</button>
         </div>
       </div>
     `;
@@ -168,7 +168,7 @@ export class SettingsPanel {
     }
 
     $('[data-action="reset-progress"]').addEventListener('click', () => {
-      if (confirm('Reset ALL game progress? This cannot be undone.')) {
+      if (confirm('모든 게임 진행도를 초기화할까요? 이 작업은 되돌릴 수 없습니다.')) {
         localStorage.removeItem('k8sgames_progress');
         localStorage.removeItem('k8sgames_investigation');
         window.location.reload();


### PR DESCRIPTION
I forked rohitg00's k8s-game repository and applied a Korean language patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an unofficial Korean distribution with localized landing pages, in-app UI text, tutorial content, and campaign/chapter/challenge labels.
  * Added Korean localization for major screens (menu, HUD, inspector, incidents, metrics, settings, context/actions) plus Korean keyboard hints.
  * Added **Noto Sans KR** typography support and updated page language/metadata.
* **Bug Fixes**
  * Updated drawing screen share-link generation to use the current page’s base URL.
* **Documentation**
  * Added `NOTICE-KO.md` and `README.ko.md`, and rewrote `README.md` with Korean patch usage and license/credit guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->